### PR TITLE
Fix control bugs

### DIFF
--- a/src/components/Controls/Controls.tsx
+++ b/src/components/Controls/Controls.tsx
@@ -25,6 +25,7 @@ const Controls: React.FunctionComponent = () => {
   const dispatch: Function = useContext(DispatchContext);
   const state: IState = useContext(StateContext);
   const {
+    controls,
     lastMessage,
     minRaiseTo,
     players,
@@ -36,16 +37,26 @@ const Controls: React.FunctionComponent = () => {
   const betAmount = players[userSeat].betAmount;
 
   const [raiseAmount, setRaiseAmount] = useState(minRaiseTo);
+
   const canCheck: boolean = toCall - betAmount === 0;
   const callAmount: number = toCall - betAmount;
   const chips: number = players[userSeat].chips;
   const totalChips: number = betAmount + chips;
+  const [showFirstRow, setShowFirstRow] = useState(true);
 
   useEffect(() => {
     if (raiseAmount > totalChips) {
       setRaiseAmount(totalChips);
     }
   }, [raiseAmount]);
+
+  useEffect(() => {
+    if (toCall >= totalChips) {
+      setShowFirstRow(false);
+    } else if (minRaiseTo >= totalChips) {
+      setShowFirstRow(false);
+    } else setShowFirstRow(true);
+  }, [controls.showControls]);
 
   // The back-end uses these numbers to interpret player actions
   // const allPossibilities = {
@@ -128,29 +139,31 @@ const Controls: React.FunctionComponent = () => {
         right: 1rem;
       `}
     >
-      <div
-        css={css`
-          display: grid;
-          grid-template-columns: 1fr 1fr 1fr 3fr;
-        `}
-      >
-        <Button
-          label="1/2 Pot"
-          small
-          onClick={() => handleSmallButtonClick("halfPot")}
-        />
-        <Button
-          label="Pot"
-          small
-          onClick={() => handleSmallButtonClick("pot")}
-        />
-        <Button
-          label="Max"
-          small
-          onClick={() => handleSmallButtonClick("max")}
-        />
-        <Slider raiseAmount={raiseAmount} setRaiseAmount={setRaiseAmount} />
-      </div>
+      {showFirstRow && (
+        <div
+          css={css`
+            display: grid;
+            grid-template-columns: 1fr 1fr 1fr 3fr;
+          `}
+        >
+          <Button
+            label="1/2 Pot"
+            small
+            onClick={() => handleSmallButtonClick("halfPot")}
+          />
+          <Button
+            label="Pot"
+            small
+            onClick={() => handleSmallButtonClick("pot")}
+          />
+          <Button
+            label="Max"
+            small
+            onClick={() => handleSmallButtonClick("max")}
+          />
+          <Slider raiseAmount={raiseAmount} setRaiseAmount={setRaiseAmount} />
+        </div>
+      )}
       {/* Fold Button */}
       <Button
         label="Fold"

--- a/src/components/Controls/Slider.tsx
+++ b/src/components/Controls/Slider.tsx
@@ -12,10 +12,24 @@ const Slider = ({ raiseAmount, setRaiseAmount }) => {
   const state: IState = useContext(StateContext);
   const { minRaiseTo, players, toCall, userSeat } = state;
 
+  const chips = players[userSeat].chips;
+  const betAmount = players[userSeat].betAmount;
+  const totalStack = chips + betAmount;
+  const step = minRaiseTo - toCall;
+
+  // Have to round up total stack to a value that is a step increment of the slider so the All-in can be rounded down accordingly
+  const roundedMax = totalStack - (totalStack % step) + toCall;
+
   // Reset the raise amount on the slider when the minimum raise changes
   useEffect(() => {
     setRaiseAmount(minRaiseTo);
   }, [minRaiseTo]);
+
+  // Round the top step of the slider down to the total stack of the player
+  const handleSliderAmount = sliderStep => {
+    if (sliderStep > totalStack) setRaiseAmount(totalStack);
+    else return setRaiseAmount(sliderStep);
+  };
 
   return (
     <div
@@ -37,12 +51,11 @@ const Slider = ({ raiseAmount, setRaiseAmount }) => {
       >
         <RCSlider
           onChange={e => {
-            setRaiseAmount(e);
+            handleSliderAmount(e);
           }}
           min={minRaiseTo}
-          step={minRaiseTo - toCall}
-          value={raiseAmount}
-          max={players[userSeat].chips + players[userSeat].betAmount}
+          step={step}
+          max={roundedMax}
         />
       </div>
     </div>


### PR DESCRIPTION
- The top row of Controls will hide if there are no increments for the minimum raise (i.e. by calling, the player will be All-In, or the minimum raise is already All-In for the player). Fixes #35.
- Fixes the bug when the last step of the slider was not registered as All-In.