### PR TITLE
Set maximum call amount to the stack size

### DIFF
--- a/src/components/Controls/Controls.tsx
+++ b/src/components/Controls/Controls.tsx
@@ -38,10 +38,10 @@ const Controls: React.FunctionComponent = () => {
 
   const [raiseAmount, setRaiseAmount] = useState(minRaiseTo);
 
-  const canCheck: boolean = toCall - betAmount === 0;
-  const callAmount: number = toCall - betAmount;
   const chips: number = players[userSeat].chips;
   const totalStack: number = betAmount + chips;
+  const canCheck: boolean = toCall - betAmount === 0;
+  const callAmount: number = toCall <= totalStack ? toCall - betAmount : chips;
   const [showFirstRow, setShowFirstRow] = useState(true);
 
   useEffect(() => {


### PR DESCRIPTION
The call amount will no longer be larger than the player's stack size. Fixes #22.