### PR TITLE
Interpret possibilties from the backend

### DIFF
--- a/src/components/Controls/Controls.tsx
+++ b/src/components/Controls/Controls.tsx
@@ -14,6 +14,7 @@ import {
 } from "../../store/actions";
 import { IState } from "../../store/initialState";
 import { IMessage } from "../Game/onMessage";
+import { Possibilities } from "../../lib/constants";
 
 // This component displays all the controls (buttons and slider) at the bottom left
 // when the player is active
@@ -56,18 +57,6 @@ const Controls: React.FunctionComponent = () => {
       setShowFirstRow(false);
     } else setShowFirstRow(true);
   }, [controls.showControls]);
-
-  // The back-end uses these numbers to interpret player actions
-  // const allPossibilities = {
-  //   0: "",
-  //   1: "small_blind",
-  //   2: "big_blind",
-  //   3: "check",
-  //   4: "raise",
-  //   5: "call",
-  //   6: "allin",
-  //   7: "fold"
-  // };
 
   const handleButtonClick = (
     action: number,
@@ -165,7 +154,9 @@ const Controls: React.FunctionComponent = () => {
       {/* Fold Button */}
       <Button
         label="Fold"
-        onClick={() => handleButtonClick(7, userSeat, null, "FOLD")}
+        onClick={() =>
+          handleButtonClick(Possibilities.fold, userSeat, null, "FOLD")
+        }
       />
       {/* Check/Call Button */}
       <Button
@@ -173,8 +164,18 @@ const Controls: React.FunctionComponent = () => {
         amount={!canCheck && callAmount}
         onClick={() =>
           canCheck
-            ? handleButtonClick(3, userSeat, callAmount, "CHECK")
-            : handleButtonClick(5, userSeat, callAmount, "CALL")
+            ? handleButtonClick(
+                Possibilities.check,
+                userSeat,
+                callAmount,
+                "CHECK"
+              )
+            : handleButtonClick(
+                Possibilities.call,
+                userSeat,
+                callAmount,
+                "CALL"
+              )
         }
       />
       {/* Raise/All-In Button */}
@@ -188,8 +189,18 @@ const Controls: React.FunctionComponent = () => {
           }
           onClick={() =>
             minRaiseTo >= chips || toCall >= chips
-              ? handleButtonClick(6, userSeat, totalStack, "ALL-IN")
-              : handleButtonClick(4, userSeat, raiseAmount, "RAISE")
+              ? handleButtonClick(
+                  Possibilities.allIn,
+                  userSeat,
+                  totalStack,
+                  "ALL-IN"
+                )
+              : handleButtonClick(
+                  Possibilities.raise,
+                  userSeat,
+                  raiseAmount,
+                  "RAISE"
+                )
           }
         />
       )}

--- a/src/components/Controls/Controls.tsx
+++ b/src/components/Controls/Controls.tsx
@@ -9,14 +9,11 @@ import {
   fold,
   log,
   sendMessage,
-  setMinRaiseTo,
-  setToCall,
   setLastAction,
   showControls
 } from "../../store/actions";
 import { IState } from "../../store/initialState";
 import { IMessage } from "../Game/onMessage";
-import { getConsoleOutput } from "@jest/console";
 
 // This component displays all the controls (buttons and slider) at the bottom left
 // when the player is active
@@ -34,13 +31,14 @@ const Controls: React.FunctionComponent = () => {
     userSeat
   } = state;
 
+  const { canCheck, canRaise } = controls;
+
   const betAmount = players[userSeat].betAmount;
 
   const [raiseAmount, setRaiseAmount] = useState(minRaiseTo);
 
   const chips: number = players[userSeat].chips;
   const totalStack: number = betAmount + chips;
-  const canCheck: boolean = toCall - betAmount === 0;
   const callAmount: number = toCall <= totalStack ? toCall - betAmount : chips;
   const [showFirstRow, setShowFirstRow] = useState(true);
 
@@ -180,7 +178,7 @@ const Controls: React.FunctionComponent = () => {
         }
       />
       {/* Raise/All-In Button */}
-      {toCall < chips && (
+      {canRaise && (
         <Button
           label={
             raiseAmount >= chips ? "All-In" : toCall === 0 ? "Bet" : "Raise to"
@@ -188,7 +186,6 @@ const Controls: React.FunctionComponent = () => {
           amount={
             minRaiseTo >= chips || toCall >= chips ? totalStack : raiseAmount
           }
-          // Need to create an isAllIn Hook and evaluate based on that
           onClick={() =>
             minRaiseTo >= chips || toCall >= chips
               ? handleButtonClick(6, userSeat, totalStack, "ALL-IN")

--- a/src/components/Controls/Controls.tsx
+++ b/src/components/Controls/Controls.tsx
@@ -137,16 +137,19 @@ const Controls: React.FunctionComponent = () => {
             label="1/2 Pot"
             small
             onClick={() => handleSmallButtonClick("halfPot")}
+            data-test="table-controls-half-pot-button"
           />
           <Button
             label="Pot"
             small
             onClick={() => handleSmallButtonClick("pot")}
+            data-test="table-controls-pot-button"
           />
           <Button
             label="Max"
             small
             onClick={() => handleSmallButtonClick("max")}
+            data-test="table-controls-max-button"
           />
           <Slider raiseAmount={raiseAmount} setRaiseAmount={setRaiseAmount} />
         </div>
@@ -157,6 +160,7 @@ const Controls: React.FunctionComponent = () => {
         onClick={() =>
           handleButtonClick(Possibilities.fold, userSeat, null, "FOLD")
         }
+        data-test="table-controls-fold-button"
       />
       {/* Check/Call Button */}
       <Button
@@ -177,6 +181,7 @@ const Controls: React.FunctionComponent = () => {
                 "CALL"
               )
         }
+        data-test="table-controls-check/call-button"
       />
       {/* Raise/All-In Button */}
       {canRaise && (
@@ -202,6 +207,7 @@ const Controls: React.FunctionComponent = () => {
                   "RAISE"
                 )
           }
+          data-test="table-controls-raise-button"
         />
       )}
     </div>

--- a/src/components/Controls/__tests__/Controls.test.js
+++ b/src/components/Controls/__tests__/Controls.test.js
@@ -21,27 +21,49 @@ describe("Controls", () => {
     expect(wrapper.find(`[label="Pot"]`)).toHaveLength(1);
     expect(wrapper.find(`[label="Max"]`)).toHaveLength(1);
     expect(wrapper.find(`[label="Fold"]`)).toHaveLength(1);
-    expect(wrapper.find(`[label="Call"]`)).toHaveLength(1);
+    expect(wrapper.find(`[label="Check"]`)).toHaveLength(1);
     expect(wrapper.find(`[label="Raise to"]`)).toHaveLength(1);
     expect(wrapper.find("Slider")).toHaveLength(1);
   });
 
-  test("shows the Call amount on the Call button when raise is not All-In", () => {
+  test("shows the Call button and the call amount", () => {
     const state = testState;
     state.toCall = 100;
+    state.controls.canCheck = false;
     const wrapper = buildWrapper(state);
 
     expect(wrapper.find(`[label="Call"]`)).toHaveLength(1);
     expect(wrapper.find(`[label="Call"]`).text()).toBe("Call 100");
   });
 
-  test("shows the Raise amount on the Raise button when raise is not All-In", () => {
+  test("shows the Raise button with the amount when Raise is not All-In", () => {
     const state = testState;
     state.minRaiseTo = 100;
+    state.controls.canRaise = true;
     const wrapper = buildWrapper(state);
 
     expect(wrapper.find(`[label="Raise to"]`)).toHaveLength(1);
     expect(wrapper.find(`[label="Raise to"]`).text()).toBe("Raise to 100");
+  });
+
+  test("shows the Check button instead of the Call button", () => {
+    const state = testState;
+    state.toCall = 100;
+    state.controls.canCheck = true;
+    const wrapper = buildWrapper(state);
+
+    expect(wrapper.find(`[label="Call"]`)).toHaveLength(0);
+    expect(wrapper.find(`[label="Check"]`)).toHaveLength(1);
+    expect(wrapper.find(`[label="Check"]`).text()).toBe("Check ");
+  });
+
+  test("hides the Raise/All-In button", () => {
+    const state = testState;
+    state.controls.canRaise = false;
+    const wrapper = buildWrapper(state);
+
+    expect(wrapper.find(`[label="Raise to"]`)).toHaveLength(0);
+    expect(wrapper.find(`[label="All-In"]`)).toHaveLength(0);
   });
 
   test("shows All-In button instead of Raise button when raise would be an all in", () => {
@@ -50,6 +72,7 @@ describe("Controls", () => {
 
     // Minimum raise is more than the player's stack
     state.minRaiseTo = 300;
+    state.controls.canRaise = true;
     let wrapper = buildWrapper(state);
 
     expect(wrapper.find(`[label="Raise to"]`)).toHaveLength(0);
@@ -61,25 +84,5 @@ describe("Controls", () => {
 
     expect(wrapper.find(`[label="Raise to"]`)).toHaveLength(0);
     expect(wrapper.find(`[label="All-In"]`)).toHaveLength(1);
-  });
-
-  test("does not show the Raise button when Call is already All-In", () => {
-    // The player's stack is 200
-    const state = testState;
-    // Call is equal to the stack
-    state.toCall = 200;
-    let wrapper = buildWrapper(state);
-
-    expect(wrapper.find(`[label="Raise to"]`)).toHaveLength(0);
-    expect(wrapper.find(`[label="All-In"]`)).toHaveLength(0);
-    expect(wrapper.find(`[label="Bet"]`)).toHaveLength(0);
-
-    // Call is larger than the stack
-    state.toCall = 300;
-    wrapper = buildWrapper(state);
-
-    expect(wrapper.find(`[label="Raise to"]`)).toHaveLength(0);
-    expect(wrapper.find(`[label="All-In"]`)).toHaveLength(0);
-    expect(wrapper.find(`[label="Bet"]`)).toHaveLength(0);
   });
 });

--- a/src/components/Controls/__tests__/Controls.test.js
+++ b/src/components/Controls/__tests__/Controls.test.js
@@ -17,12 +17,24 @@ describe("Controls", () => {
     const state = testState;
     const wrapper = buildWrapper(state);
 
-    expect(wrapper.find(`[label="1/2 Pot"]`)).toHaveLength(1);
-    expect(wrapper.find(`[label="Pot"]`)).toHaveLength(1);
-    expect(wrapper.find(`[label="Max"]`)).toHaveLength(1);
-    expect(wrapper.find(`[label="Fold"]`)).toHaveLength(1);
-    expect(wrapper.find(`[label="Check"]`)).toHaveLength(1);
-    expect(wrapper.find(`[label="Raise to"]`)).toHaveLength(1);
+    expect(
+      wrapper.find(`[data-test="table-controls-half-pot-button"]`)
+    ).toHaveLength(1);
+    expect(
+      wrapper.find(`[data-test="table-controls-pot-button"]`)
+    ).toHaveLength(1);
+    expect(
+      wrapper.find(`[data-test="table-controls-max-button"]`)
+    ).toHaveLength(1);
+    expect(
+      wrapper.find(`[data-test="table-controls-fold-button"]`)
+    ).toHaveLength(1);
+    expect(
+      wrapper.find(`[data-test="table-controls-check/call-button"]`)
+    ).toHaveLength(1);
+    expect(
+      wrapper.find(`[data-test="table-controls-raise-button"]`)
+    ).toHaveLength(1);
     expect(wrapper.find("Slider")).toHaveLength(1);
   });
 
@@ -32,8 +44,12 @@ describe("Controls", () => {
     state.controls.canCheck = false;
     const wrapper = buildWrapper(state);
 
-    expect(wrapper.find(`[label="Call"]`)).toHaveLength(1);
-    expect(wrapper.find(`[label="Call"]`).text()).toBe("Call 100");
+    expect(
+      wrapper.find(`[data-test="table-controls-check/call-button"]`)
+    ).toHaveLength(1);
+    expect(
+      wrapper.find(`[data-test="table-controls-check/call-button"]`).text()
+    ).toBe("Call 100");
   });
 
   test("shows the Raise button with the amount when Raise is not All-In", () => {
@@ -42,8 +58,12 @@ describe("Controls", () => {
     state.controls.canRaise = true;
     const wrapper = buildWrapper(state);
 
-    expect(wrapper.find(`[label="Raise to"]`)).toHaveLength(1);
-    expect(wrapper.find(`[label="Raise to"]`).text()).toBe("Raise to 100");
+    expect(
+      wrapper.find(`[data-test="table-controls-raise-button"]`)
+    ).toHaveLength(1);
+    expect(
+      wrapper.find(`[data-test="table-controls-raise-button"]`).text()
+    ).toBe("Raise to 100");
   });
 
   test("shows the Check button instead of the Call button", () => {
@@ -52,9 +72,12 @@ describe("Controls", () => {
     state.controls.canCheck = true;
     const wrapper = buildWrapper(state);
 
-    expect(wrapper.find(`[label="Call"]`)).toHaveLength(0);
-    expect(wrapper.find(`[label="Check"]`)).toHaveLength(1);
-    expect(wrapper.find(`[label="Check"]`).text()).toBe("Check ");
+    expect(
+      wrapper.find(`[data-test="table-controls-check/call-button"]`)
+    ).toHaveLength(1);
+    expect(
+      wrapper.find(`[data-test="table-controls-check/call-button"]`).text()
+    ).toBe("Check ");
   });
 
   test("hides the Raise/All-In button", () => {
@@ -62,8 +85,9 @@ describe("Controls", () => {
     state.controls.canRaise = false;
     const wrapper = buildWrapper(state);
 
-    expect(wrapper.find(`[label="Raise to"]`)).toHaveLength(0);
-    expect(wrapper.find(`[label="All-In"]`)).toHaveLength(0);
+    expect(
+      wrapper.find(`[data-test="table-controls-raise-button"]`)
+    ).toHaveLength(0);
   });
 
   test("shows All-In button instead of Raise button when raise would be an all in", () => {
@@ -75,14 +99,22 @@ describe("Controls", () => {
     state.controls.canRaise = true;
     let wrapper = buildWrapper(state);
 
-    expect(wrapper.find(`[label="Raise to"]`)).toHaveLength(0);
-    expect(wrapper.find(`[label="All-In"]`)).toHaveLength(1);
+    expect(
+      wrapper.find(`[data-test="table-controls-raise-button"]`)
+    ).toHaveLength(1);
+    expect(
+      wrapper.find(`[data-test="table-controls-raise-button"]`).text()
+    ).toBe("All-In 200");
 
     // Minimum raise is equals the player's stack
     state.minRaiseTo = 200;
     wrapper = buildWrapper(state);
 
-    expect(wrapper.find(`[label="Raise to"]`)).toHaveLength(0);
-    expect(wrapper.find(`[label="All-In"]`)).toHaveLength(1);
+    expect(
+      wrapper.find(`[data-test="table-controls-raise-button"]`)
+    ).toHaveLength(1);
+    expect(
+      wrapper.find(`[data-test="table-controls-raise-button"]`).text()
+    ).toBe("All-In 200");
   });
 });

--- a/src/components/Game/onMessage.ts
+++ b/src/components/Game/onMessage.ts
@@ -26,7 +26,8 @@ import {
   showDown,
   updateGameTurn,
   updateStateValue,
-  setBoardCards
+  setBoardCards,
+  processControls
 } from "../../store/actions";
 import playerStringToId from "../../lib/playerStringToId";
 import numberWithCommas from "../../lib/numberWithCommas";
@@ -253,6 +254,7 @@ export const onMessage_player = (
           updateTotalPot(message.pot, dispatch);
           setMinRaiseTo(message.minRaiseTo, dispatch);
           setToCall(message.toCall, dispatch);
+          processControls(message.possibilities, dispatch);
           showControls(true, dispatch);
           break;
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,9 @@
+export enum Possibilities {
+  "smallBlind" = 1,
+  "bigBlind" = 2,
+  "check" = 3,
+  "raise" = 4,
+  "call" = 5,
+  "allIn" = 6,
+  "fold" = 7
+}

--- a/src/store/__tests__/actions.test.js
+++ b/src/store/__tests__/actions.test.js
@@ -1,6 +1,6 @@
 import * as actions from "../actions";
 
-describe("actions", () => {
+describe("addToHandHistory", () => {
   const dispatch = jest.fn();
 
   test("dispatches the hand history with the last action", () => {
@@ -9,5 +9,42 @@ describe("actions", () => {
 
     actions.addToHandHistory(lastAction, dispatch);
     expect(dispatch).toHaveBeenCalledWith({ payload: lastAction, type });
+  });
+});
+
+describe("processControls", () => {
+  const dispatch = jest.fn();
+
+  test("dispatches with both Check and Raise disabled", () => {
+    const possibilities = [6, 7];
+    const type = "processControls";
+
+    actions.processControls(possibilities, dispatch);
+    expect(dispatch).toHaveBeenCalledWith({
+      payload: { canCheck: false, canRaise: false },
+      type
+    });
+  });
+
+  test("dispatches with Check enabled", () => {
+    const possibilities = [3];
+    const type = "processControls";
+
+    actions.processControls(possibilities, dispatch);
+    expect(dispatch).toHaveBeenCalledWith({
+      payload: { canCheck: true, canRaise: false },
+      type
+    });
+  });
+
+  test("dispatches with Raise enabled", () => {
+    const possibilities = [4];
+    const type = "processControls";
+
+    actions.processControls(possibilities, dispatch);
+    expect(dispatch).toHaveBeenCalledWith({
+      payload: { canCheck: false, canRaise: true },
+      type
+    });
   });
 });

--- a/src/store/__tests__/reducer.test.js
+++ b/src/store/__tests__/reducer.test.js
@@ -39,4 +39,20 @@ describe("reducer", () => {
       ]
     });
   });
+
+  test("handles processControls", () => {
+    const action = {
+      payload: { canCheck: false, canRaise: false },
+      type: "processControls"
+    };
+
+    expect(reducer(state, action)).toEqual({
+      ...initialState,
+      controls: {
+        ...initialState.controls,
+        canCheck: false,
+        canRaise: false
+      }
+    });
+  });
 });

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -4,6 +4,7 @@ import playerIdToString from "../lib/playerIdToString";
 import lowerCaseLastLetter from "../lib/lowerCaseLastLetter";
 import { IState } from "./initialState";
 import { IMessage } from "../components/Game/onMessage";
+import { Possibilities } from "../lib/constants";
 
 // Add logs to the hand history to display them in the LogBox
 export const addToHandHistory = (
@@ -207,11 +208,11 @@ export const playerJoin = (
 
 // Defines which buttons to show in Controls by processsing the possibilities array
 export const processControls = (
-  possibilities: number[],
+  receivedPossibilities: number[],
   dispatch: Function
 ) => {
-  const canCheck = possibilities.some(e => e === 3);
-  const canRaise = possibilities.some(e => e === 4);
+  const canCheck = receivedPossibilities.some(e => e === Possibilities.check);
+  const canRaise = receivedPossibilities.some(e => e === Possibilities.raise);
 
   dispatch({
     type: "processControls",

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -205,6 +205,23 @@ export const playerJoin = (
   );
 };
 
+// Defines which buttons to show in Controls by processsing the possibilities array
+export const processControls = (
+  possibilities: number[],
+  dispatch: Function
+) => {
+  const canCheck = possibilities.some(e => e === 3);
+  const canRaise = possibilities.some(e => e === 4);
+
+  dispatch({
+    type: "processControls",
+    payload: {
+      canCheck,
+      canRaise
+    }
+  });
+};
+
 export const resetMessage = (node: string, dispatch: Function): void => {
   dispatch({
     type: "setMessage",

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -211,8 +211,12 @@ export const processControls = (
   receivedPossibilities: number[],
   dispatch: Function
 ) => {
-  const canCheck = receivedPossibilities.some(e => e === Possibilities.check);
-  const canRaise = receivedPossibilities.some(e => e === Possibilities.raise);
+  const canCheck = receivedPossibilities.some(
+    poss => poss === Possibilities.check
+  );
+  const canRaise = receivedPossibilities.some(
+    poss => poss === Possibilities.raise
+  );
 
   dispatch({
     type: "processControls",

--- a/src/store/initialState.ts
+++ b/src/store/initialState.ts
@@ -27,7 +27,7 @@ const initialState: IState = {
   // Which seat is the active player
   activePlayer: null,
   // Current blinds - small and big one
-  blinds: [0, 0],
+  blinds: [1, 2],
   // Board Cards
   boardCards: [],
   // Connection status dispalyed at the top
@@ -40,7 +40,9 @@ const initialState: IState = {
   },
   controls: {
     showControls: false,
-    showFirstRow: true
+    showFirstRow: true,
+    canCheck: false,
+    canRaise: true
   },
   // Whether the cards have been dealt
   cardsDealt: false,
@@ -145,7 +147,12 @@ export interface IState {
     player2: string;
     echo: string;
   };
-  controls: { showControls: boolean; showFirstRow: boolean };
+  controls: {
+    canCheck: boolean;
+    canRaise: boolean;
+    showControls: boolean;
+    showFirstRow: boolean;
+  };
   cardsDealt: boolean;
   chipsCollected: boolean;
   dealer: number;

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -122,6 +122,16 @@ const reducer: Function = (state: IState, action: IAction): object => {
         }
       };
     }
+    case "processControls": {
+      return {
+        ...state,
+        controls: {
+          ...state.controls,
+          canCheck: action.payload.canCheck,
+          canRaise: action.payload.canRaise
+        }
+      };
+    }
     case "resetTurn": {
       return {
         ...state,

--- a/src/store/testState.ts
+++ b/src/store/testState.ts
@@ -41,6 +41,8 @@ const initialState: IState = {
     echo: "Not connected"
   },
   controls: {
+    canCheck: true,
+    canRaise: true,
     showControls: false,
     showFirstRow: true
   },


### PR DESCRIPTION
Before each player's turn to act, the backend sends a `possibilities` array with options of what the possible player actions are. These options are:

```
    0: "",
    1: "small_blind",
    2: "big_blind",
    3: "check",
    4: "raise",
    5: "call",
    6: "allin",
    7: "fold"
  ```

Up until now, the frontend did not interpret this array at all - the potential player actions were all calculated on the client side. 

This PR introduces interpreting wether a player can `check` or `raise`. These two are the most important, because:

- `fold` is always possible
- `call` is always possible if `check` isn't
- `all-in` is always possible if `raise` is possible
- `small_blind` and `big_blind` are automatically being placed (for now)

Therefore all we need ot monitor is wether `check` or `raise` is possible.

This PR addresses #51, although to completely fix the issue, @sg777 will have to update the backend.