### PR TITLE
Fix active player handling

### DIFF
--- a/src/components/Game/__tests__/onMessage.test.ts
+++ b/src/components/Game/__tests__/onMessage.test.ts
@@ -1,40 +1,38 @@
-import { IReceivedMessage, onMessage_player } from "../onMessage";
+import { IMessage, onMessage_player } from "../onMessage";
 import state from "../../../store/initialState";
 import * as actions from "../../../store/actions";
 
-describe("onMessage ", () => {
-  const dispatch = jest.fn();
+const dispatch = jest.fn();
 
-  const addToHandHistorySpy = jest.spyOn(actions, "addToHandHistory");
+const receiveMessage = (message: IMessage) => {
+  const {
+    action,
+    showInfo,
+    method,
+    playerid,
+    bet_amount,
+    winners,
+    win_amount
+  } = message;
 
-  const receiveMessage = (message: IReceivedMessage) => {
-    const {
+  onMessage_player(
+    JSON.stringify({
       action,
-      showInfo,
+      bet_amount,
       method,
       playerid,
-      bet_amount,
-      winners,
-      win_amount
-    } = message;
+      showInfo,
+      win_amount,
+      winners
+    }),
+    `player${playerid + 1}`,
+    state,
+    dispatch
+  );
+};
 
-    onMessage_player(
-      JSON.stringify({
-        action,
-        bet_amount,
-        method,
-        playerid,
-        showInfo,
-        win_amount,
-        winners
-      }),
-      `player${playerid + 1}`,
-      state,
-      dispatch
-    );
-  };
-
-  // Tests for Hand History
+describe("handHistory", () => {
+  const addToHandHistorySpy = jest.spyOn(actions, "addToHandHistory");
 
   test("logs posting the blinds from the Small Blind's perspective", () => {
     receiveMessage({

--- a/src/components/Game/__tests__/onMessage.test.ts
+++ b/src/components/Game/__tests__/onMessage.test.ts
@@ -177,7 +177,7 @@ describe("Active player handling", () => {
   const setActivePlayerSpy = jest.spyOn(actions, "setActivePlayer");
   const showControlsSpy = jest.spyOn(actions, "showControls");
 
-  test("reveals the controls for the player at userSeat", () => {
+  test("reveal the controls for the player at userSeat", () => {
     receiveMessage(
       {
         action: "round_betting",
@@ -192,7 +192,7 @@ describe("Active player handling", () => {
     expect(showControlsSpy).toHaveBeenCalledWith(true, dispatch);
   });
 
-  test("does not reveals the controls when it's the opponent's turn", () => {
+  test("does not reveal the controls when it's the opponent's turn", () => {
     receiveMessage(
       {
         action: "round_betting",

--- a/src/components/Game/onMessage.ts
+++ b/src/components/Game/onMessage.ts
@@ -64,7 +64,7 @@ export interface IMessage {
   toPlayer?: number;
   toCall?: number;
   win_amount?: number;
-  winners?: number;
+  winners?: number[];
 }
 
 export const onMessage = (

--- a/src/components/Game/onMessage.ts
+++ b/src/components/Game/onMessage.ts
@@ -250,12 +250,17 @@ export const onMessage_player = (
             message.player_funds.forEach((balance: number, index: number) => {
               setBalance(playerIdToString(index), balance, dispatch);
             });
-          setActivePlayer(player, dispatch);
+
+          setActivePlayer(playerIdToString(guiPlayer), dispatch);
           updateTotalPot(message.pot, dispatch);
           setMinRaiseTo(message.minRaiseTo, dispatch);
           setToCall(message.toCall, dispatch);
-          processControls(message.possibilities, dispatch);
-          showControls(true, dispatch);
+
+          // Turn on controls if it's the current player's turn
+          if (playerId === guiPlayer) {
+            processControls(message.possibilities, dispatch);
+            showControls(true, dispatch);
+          }
           break;
 
         // Update other players actions


### PR DESCRIPTION
This PR fixes active player highlighting and fixes a bug that made the controls appear every time it was a new player's turn. Added test coverage, also.

Fixes #20. 
Fixes #47.