### PR TITLE
Fix previously shown playerCards exposing

### DIFF
--- a/src/store/__tests__/actions.test.js
+++ b/src/store/__tests__/actions.test.js
@@ -47,4 +47,16 @@ describe("processControls", () => {
       type
     });
   });
+
+  describe("resetTurn", () => {
+    const dispatch = jest.fn();
+
+    test("dispatches the hand history with the last action", () => {
+      const bigBlind = 100;
+      const type = "resetTurn";
+
+      actions.resetTurn(bigBlind, dispatch);
+      expect(dispatch).toHaveBeenCalledWith({ payload: bigBlind, type });
+    });
+  });
 });

--- a/src/store/__tests__/reducer.test.js
+++ b/src/store/__tests__/reducer.test.js
@@ -66,6 +66,7 @@ describe("reducer", () => {
       ...initialState,
       chipsCollected: false,
       minRaiseTo: action.payload,
+      isShowDown: false,
       players: {
         ...state.players,
         player1: {

--- a/src/store/__tests__/reducer.test.js
+++ b/src/store/__tests__/reducer.test.js
@@ -55,4 +55,32 @@ describe("reducer", () => {
       }
     });
   });
+
+  test("handles resetTurn", () => {
+    const action = {
+      payload: 100,
+      type: "resetTurn"
+    };
+
+    expect(reducer(state, action)).toEqual({
+      ...initialState,
+      chipsCollected: false,
+      minRaiseTo: action.payload,
+      players: {
+        ...state.players,
+        player1: {
+          ...state.players.player1,
+          isBetting: false,
+          betAmount: 0,
+          playerCards: []
+        },
+        player2: {
+          ...state.players.player2,
+          isBetting: false,
+          betAmount: 0,
+          playerCards: []
+        }
+      }
+    });
+  });
 });

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -142,12 +142,14 @@ const reducer: Function = (state: IState, action: IAction): object => {
           player1: {
             ...state.players.player1,
             isBetting: false,
-            betAmount: 0
+            betAmount: 0,
+            playerCards: []
           },
           player2: {
             ...state.players.player2,
             isBetting: false,
-            betAmount: 0
+            betAmount: 0,
+            playerCards: []
           }
         }
       };

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -137,6 +137,7 @@ const reducer: Function = (state: IState, action: IAction): object => {
         ...state,
         chipsCollected: false,
         minRaiseTo: action.payload,
+        isShowDown: false,
         players: {
           ...state.players,
           player1: {


### PR DESCRIPTION
Fixes a bug that causes playerCards to expose in subsequent hands when they shouldn't.

Fixes #60.