### PR TITLE
Fix unresposive Call button

### DIFF
--- a/src/components/Controls/Controls.tsx
+++ b/src/components/Controls/Controls.tsx
@@ -68,28 +68,42 @@ const Controls: React.FunctionComponent = () => {
     let nextAction: IMessage = lastMessage;
     nextAction.playerid = playerStringToId(player);
 
-    // Check
-    if (amount === 0) {
-      log(`${player} checks`, "info");
+    // Match action to possibilities
+    switch (action) {
+      // Check
+      case Possibilities.check:
+        log(`${player} checks`, "info");
+        break;
+
       // Call
-    } else if (amount + betAmount === toCall) {
-      nextAction.bet_amount = amount + betAmount;
-      bet(player, amount + betAmount, state, dispatch);
-      log(`${player} calls ${amount}`, "info");
+      case Possibilities.call:
+        nextAction.bet_amount = amount + betAmount;
+        bet(player, amount + betAmount, state, dispatch);
+        log(`${player} calls ${amount}`, "info");
+        break;
+
       // Raise
-    } else if (amount > toCall) {
-      nextAction.bet_amount = amount;
-      bet(player, amount, state, dispatch);
-      log(
-        `${player} raises to ${amount} ${lastAction === "ALL-IN" &&
-          " and is All-in"}`,
-        "info"
-      );
+      case Possibilities.raise:
+        nextAction.bet_amount = amount;
+        bet(player, amount, state, dispatch);
+        log(
+          `${player} raises to ${amount} ${lastAction === "ALL-IN" &&
+            " and is All-in"}`,
+          "info"
+        );
+        break;
+
       // Fold
-    } else if (action === Possibilities.fold) {
-      fold(player, dispatch);
-      log(`${player} folds`, "info");
-    } else throw new Error("Something is wrong with the betamount.");
+      case Possibilities.fold:
+        fold(player, dispatch);
+        log(`${player} folds`, "info");
+        break;
+
+      // Error
+      default:
+        throw new Error(`Invalid possibility value: ${action}`);
+    }
+
     // Hide Controls
     showControls(false, dispatch);
     // Update the player's name with the last action

--- a/src/components/Controls/Controls.tsx
+++ b/src/components/Controls/Controls.tsx
@@ -14,7 +14,7 @@ import {
 } from "../../store/actions";
 import { IState } from "../../store/initialState";
 import { IMessage } from "../Game/onMessage";
-import { Possibilities } from "../../lib/constants";
+import { Possibilities, PlayerActions } from "../../lib/constants";
 
 // This component displays all the controls (buttons and slider) at the bottom left
 // when the player is active
@@ -89,7 +89,7 @@ const Controls: React.FunctionComponent = () => {
         bet(player, amount, state, dispatch);
         log(
           `${player} raises to ${amount} ${
-            lastAction === "ALL-IN" ? "and is All-in" : ""
+            lastAction === PlayerActions.allIn ? "and is All-in" : ""
           }`,
           "info"
         );
@@ -174,7 +174,12 @@ const Controls: React.FunctionComponent = () => {
       <Button
         label="Fold"
         onClick={() =>
-          handleButtonClick(Possibilities.fold, userSeat, null, "FOLD")
+          handleButtonClick(
+            Possibilities.fold,
+            userSeat,
+            null,
+            PlayerActions.fold
+          )
         }
         data-test="table-controls-fold-button"
       />
@@ -188,13 +193,13 @@ const Controls: React.FunctionComponent = () => {
                 Possibilities.check,
                 userSeat,
                 callAmount,
-                "CHECK"
+                PlayerActions.check
               )
             : handleButtonClick(
                 Possibilities.call,
                 userSeat,
                 callAmount,
-                "CALL"
+                PlayerActions.call
               )
         }
         data-test={`table-controls-${canCheck ? "check" : "call"}-button`}
@@ -214,13 +219,13 @@ const Controls: React.FunctionComponent = () => {
                   Possibilities.allIn,
                   userSeat,
                   totalStack,
-                  "ALL-IN"
+                  PlayerActions.allIn
                 )
               : handleButtonClick(
                   Possibilities.raise,
                   userSeat,
                   raiseAmount,
-                  "RAISE"
+                  PlayerActions.raise
                 )
           }
           data-test="table-controls-raise-button"

--- a/src/components/Controls/Controls.tsx
+++ b/src/components/Controls/Controls.tsx
@@ -195,7 +195,7 @@ const Controls: React.FunctionComponent = () => {
                 "CALL"
               )
         }
-        data-test="table-controls-check/call-button"
+        data-test={`table-controls-${canCheck ? "check" : "call"}-button`}
       />
       {/* Raise/All-In Button */}
       {canRaise && (

--- a/src/components/Controls/Controls.tsx
+++ b/src/components/Controls/Controls.tsx
@@ -86,7 +86,7 @@ const Controls: React.FunctionComponent = () => {
         "info"
       );
       // Fold
-    } else if (action === 7) {
+    } else if (action === Possibilities.fold) {
       fold(player, dispatch);
       log(`${player} folds`, "info");
     } else throw new Error("Something is wrong with the betamount.");

--- a/src/components/Controls/Controls.tsx
+++ b/src/components/Controls/Controls.tsx
@@ -88,8 +88,9 @@ const Controls: React.FunctionComponent = () => {
         nextAction.bet_amount = amount;
         bet(player, amount, state, dispatch);
         log(
-          `${player} raises to ${amount} ${lastAction === "ALL-IN" &&
-            " and is All-in"}`,
+          `${player} raises to ${amount} ${
+            lastAction === "ALL-IN" ? "and is All-in" : ""
+          }`,
           "info"
         );
         break;

--- a/src/components/Controls/Controls.tsx
+++ b/src/components/Controls/Controls.tsx
@@ -84,6 +84,7 @@ const Controls: React.FunctionComponent = () => {
 
       // Raise
       case Possibilities.raise:
+      case Possibilities.allIn:
         nextAction.bet_amount = amount;
         bet(player, amount, state, dispatch);
         log(

--- a/src/components/Controls/__tests__/Controls.test.js
+++ b/src/components/Controls/__tests__/Controls.test.js
@@ -161,4 +161,30 @@ describe("Button clicks", () => {
     expect(showControls).toHaveBeenCalledTimes(1);
     expect(showControls).toHaveBeenCalledWith(false, expect.anything());
   });
+
+  test("handles Check button when clicked", () => {
+    const state = testState;
+    state.showControls = true;
+    state.userSeat = "player1";
+    state.players.player1.betAmount = 0;
+
+    const wrapper = buildWrapper(state);
+
+    wrapper.find(`[data-test="table-controls-check-button"]`).simulate("click");
+
+    // Sends fold to the backend
+    expect(sendMessage).toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ possibilities: [Possibilities.check] }),
+      "player1",
+      state,
+      expect.anything()
+    );
+
+    // Hides the Controls
+    expect(showControls).toHaveBeenCalled();
+    expect(showControls).toHaveBeenCalledTimes(1);
+    expect(showControls).toHaveBeenCalledWith(false, expect.anything());
+  });
 });

--- a/src/components/Controls/__tests__/Controls.test.js
+++ b/src/components/Controls/__tests__/Controls.test.js
@@ -19,7 +19,7 @@ const buildWrapper = stateToTest => {
 
 describe("Controls", () => {
   test("displays all the controls by default", () => {
-    const state = testState;
+    const state = { ...testState };
     const wrapper = buildWrapper(state);
 
     expect(
@@ -44,9 +44,12 @@ describe("Controls", () => {
   });
 
   test("shows the Call button and the call amount", () => {
-    const state = testState;
-    state.toCall = 100;
-    state.controls.canCheck = false;
+    const state = {
+      ...testState,
+      toCall: 100,
+      controls: { ...testState.controls, canCheck: false }
+    };
+
     const wrapper = buildWrapper(state);
 
     expect(
@@ -58,9 +61,11 @@ describe("Controls", () => {
   });
 
   test("shows the Raise button with the amount when Raise is not All-In", () => {
-    const state = testState;
-    state.minRaiseTo = 100;
-    state.controls.canRaise = true;
+    const state = {
+      ...testState,
+      minRaiseTo: 100,
+      controls: { ...testState.controls, canRaise: true }
+    };
     const wrapper = buildWrapper(state);
 
     expect(
@@ -72,9 +77,11 @@ describe("Controls", () => {
   });
 
   test("shows the Check button instead of the Call button", () => {
-    const state = testState;
-    state.toCall = 100;
-    state.controls.canCheck = true;
+    const state = {
+      ...testState,
+      toCall: 100,
+      controls: { ...testState.controls, canCheck: true }
+    };
     const wrapper = buildWrapper(state);
 
     expect(
@@ -86,8 +93,10 @@ describe("Controls", () => {
   });
 
   test("hides the Raise/All-In button", () => {
-    const state = testState;
-    state.controls.canRaise = false;
+    const state = {
+      ...testState,
+      controls: { ...testState.controls, canRaise: false }
+    };
     const wrapper = buildWrapper(state);
 
     expect(
@@ -97,11 +106,12 @@ describe("Controls", () => {
 
   test("shows All-In button instead of Raise button when raise would be an all in", () => {
     // The player's stack is 200
-    const state = testState;
-
-    // Minimum raise is more than the player's stack
-    state.minRaiseTo = 300;
-    state.controls.canRaise = true;
+    const state = {
+      ...testState,
+      // Minimum raise is more than the player's stack
+      minRaiseTo: 300,
+      controls: { ...testState.controls, canRaise: true }
+    };
     let wrapper = buildWrapper(state);
 
     expect(
@@ -134,10 +144,15 @@ describe("Button clicks", () => {
   const { bet, fold, sendMessage, setLastAction, showControls } = actions;
 
   test("handles Fold button when clicked", () => {
-    const state = testState;
-    state.controls.showControls = true;
-    state.userSeat = "player1";
-    state.players.player1.betAmount = 0;
+    const state = {
+      ...testState,
+      controls: { ...testState.controls, showControls: true },
+      userSeat: "player1",
+      players: {
+        ...testState.players,
+        player1: { ...testState.players.player1, betAmount: 0 }
+      }
+    };
 
     const wrapper = buildWrapper(state);
 
@@ -168,10 +183,15 @@ describe("Button clicks", () => {
   });
 
   test("handles Check button when clicked", () => {
-    const state = testState;
-    state.controls.showControls = true;
-    state.userSeat = "player1";
-    state.players.player1.betAmount = 0;
+    const state = {
+      ...testState,
+      controls: { ...testState.controls, showControls: true },
+      userSeat: "player1",
+      players: {
+        ...testState.players,
+        player1: { ...testState.players.player1, betAmount: 0 }
+      }
+    };
 
     const wrapper = buildWrapper(state);
 
@@ -199,12 +219,16 @@ describe("Button clicks", () => {
   });
 
   test("handles Call button when clicked", () => {
-    const state = testState;
-    state.controls.showControls = true;
-    state.userSeat = "player1";
-    state.controls.canCheck = false;
-    state.toCall = 100;
-    state.players.player1.betAmount = 0;
+    const state = {
+      ...testState,
+      controls: { ...testState.controls, showControls: true, canCheck: false },
+      userSeat: "player1",
+      players: {
+        ...testState.players,
+        player1: { ...testState.players.player1, betAmount: 0 }
+      },
+      toCall: 100
+    };
 
     const wrapper = buildWrapper(state);
 
@@ -238,12 +262,16 @@ describe("Button clicks", () => {
   });
 
   test("handles Raise button when clicked", () => {
-    const state = testState;
-    state.controls.showControls = true;
-    state.userSeat = "player1";
-    state.minRaiseTo = 50;
-    state.controls.canCheck = false;
-    state.players.player1.betAmount = 0;
+    const state = {
+      ...testState,
+      controls: { ...testState.controls, showControls: true, canCheck: false },
+      userSeat: "player1",
+      players: {
+        ...testState.players,
+        player1: { ...testState.players.player1, betAmount: 0 }
+      },
+      minRaiseTo: 50
+    };
 
     const wrapper = buildWrapper(state);
 
@@ -277,13 +305,16 @@ describe("Button clicks", () => {
   });
 
   test("handles All-In button when clicked", () => {
-    const state = testState;
-    state.controls.showControls = true;
-    state.userSeat = "player1";
-    state.minRaiseTo = 200;
-    state.players.player1.chips = 200;
-    state.controls.canCheck = false;
-    state.players.player1.betAmount = 0;
+    const state = {
+      ...testState,
+      controls: { ...testState.controls, showControls: true, canCheck: false },
+      userSeat: "player1",
+      players: {
+        ...testState.players,
+        player1: { ...testState.players.player1, betAmount: 0 }
+      },
+      minRaiseTo: 200
+    };
 
     const wrapper = buildWrapper(state);
 

--- a/src/components/Controls/__tests__/Controls.test.js
+++ b/src/components/Controls/__tests__/Controls.test.js
@@ -224,4 +224,77 @@ describe("Button clicks", () => {
     expect(showControls).toHaveBeenCalledTimes(1);
     expect(showControls).toHaveBeenCalledWith(false, expect.anything());
   });
+
+  test("handles Raise button when clicked", () => {
+    const state = testState;
+    state.showControls = true;
+    state.userSeat = "player1";
+    state.minRaiseTo = 50;
+    state.controls.canCheck = false;
+    state.players.player1.betAmount = 0;
+
+    const wrapper = buildWrapper(state);
+
+    wrapper.find(`[data-test="table-controls-raise-button"]`).simulate("click");
+
+    // Sends fold to the GUI
+    expect(bet).toHaveBeenCalled();
+    expect(bet).toHaveBeenCalledTimes(1);
+    expect(bet).toHaveBeenCalledWith("player1", 50, state, expect.anything());
+
+    // Sends call to the backend
+    expect(sendMessage).toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        possibilities: [Possibilities.raise],
+        bet_amount: 50
+      }),
+      "player1",
+      state,
+      expect.anything()
+    );
+
+    // Hides the Controls
+    expect(showControls).toHaveBeenCalled();
+    expect(showControls).toHaveBeenCalledTimes(1);
+    expect(showControls).toHaveBeenCalledWith(false, expect.anything());
+  });
+
+  test("handles AllIn button when clicked", () => {
+    const state = testState;
+    state.showControls = true;
+    state.userSeat = "player1";
+    state.minRaiseTo = 200;
+    state.players.player1.chips = 200;
+    state.controls.canCheck = false;
+    state.players.player1.betAmount = 0;
+
+    const wrapper = buildWrapper(state);
+
+    wrapper.find(`[data-test="table-controls-raise-button"]`).simulate("click");
+
+    // Sends fold to the GUI
+    expect(bet).toHaveBeenCalled();
+    expect(bet).toHaveBeenCalledTimes(1);
+    expect(bet).toHaveBeenCalledWith("player1", 200, state, expect.anything());
+
+    // Sends call to the backend
+    expect(sendMessage).toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        possibilities: [Possibilities.allIn],
+        bet_amount: 200
+      }),
+      "player1",
+      state,
+      expect.anything()
+    );
+
+    // Hides the Controls
+    expect(showControls).toHaveBeenCalled();
+    expect(showControls).toHaveBeenCalledTimes(1);
+    expect(showControls).toHaveBeenCalledWith(false, expect.anything());
+  });
 });

--- a/src/components/Controls/__tests__/Controls.test.js
+++ b/src/components/Controls/__tests__/Controls.test.js
@@ -35,7 +35,7 @@ describe("Controls", () => {
       wrapper.find(`[data-test="table-controls-fold-button"]`)
     ).toHaveLength(1);
     expect(
-      wrapper.find(`[data-test="table-controls-check/call-button"]`)
+      wrapper.find(`[data-test="table-controls-check-button"]`)
     ).toHaveLength(1);
     expect(
       wrapper.find(`[data-test="table-controls-raise-button"]`)
@@ -50,10 +50,10 @@ describe("Controls", () => {
     const wrapper = buildWrapper(state);
 
     expect(
-      wrapper.find(`[data-test="table-controls-check/call-button"]`)
+      wrapper.find(`[data-test="table-controls-call-button"]`)
     ).toHaveLength(1);
     expect(
-      wrapper.find(`[data-test="table-controls-check/call-button"]`).text()
+      wrapper.find(`[data-test="table-controls-call-button"]`).text()
     ).toBe("Call 100");
   });
 
@@ -78,10 +78,10 @@ describe("Controls", () => {
     const wrapper = buildWrapper(state);
 
     expect(
-      wrapper.find(`[data-test="table-controls-check/call-button"]`)
+      wrapper.find(`[data-test="table-controls-check-button"]`)
     ).toHaveLength(1);
     expect(
-      wrapper.find(`[data-test="table-controls-check/call-button"]`).text()
+      wrapper.find(`[data-test="table-controls-check-button"]`).text()
     ).toBe("Check ");
   });
 

--- a/src/components/Controls/__tests__/Controls.test.js
+++ b/src/components/Controls/__tests__/Controls.test.js
@@ -134,7 +134,7 @@ describe("Button clicks", () => {
 
   test("handles Fold button when clicked", () => {
     const state = testState;
-    state.showControls = true;
+    state.controls.showControls = true;
     state.userSeat = "player1";
     state.players.player1.betAmount = 0;
 
@@ -165,7 +165,7 @@ describe("Button clicks", () => {
 
   test("handles Check button when clicked", () => {
     const state = testState;
-    state.showControls = true;
+    state.controls.showControls = true;
     state.userSeat = "player1";
     state.players.player1.betAmount = 0;
 
@@ -191,7 +191,7 @@ describe("Button clicks", () => {
 
   test("handles Call button when clicked", () => {
     const state = testState;
-    state.showControls = true;
+    state.controls.showControls = true;
     state.userSeat = "player1";
     state.controls.canCheck = false;
     state.toCall = 100;
@@ -227,7 +227,7 @@ describe("Button clicks", () => {
 
   test("handles Raise button when clicked", () => {
     const state = testState;
-    state.showControls = true;
+    state.controls.showControls = true;
     state.userSeat = "player1";
     state.minRaiseTo = 50;
     state.controls.canCheck = false;
@@ -263,7 +263,7 @@ describe("Button clicks", () => {
 
   test("handles AllIn button when clicked", () => {
     const state = testState;
-    state.showControls = true;
+    state.controls.showControls = true;
     state.userSeat = "player1";
     state.minRaiseTo = 200;
     state.players.player1.chips = 200;

--- a/src/components/Controls/__tests__/Controls.test.js
+++ b/src/components/Controls/__tests__/Controls.test.js
@@ -4,7 +4,7 @@ import Controls from "../Controls";
 import { StateContext, DispatchContext } from "../../../store/context";
 import testState from "../../../store/testState";
 import * as actions from "../../../store/actions";
-import { Possibilities } from "../../../lib/constants";
+import { Possibilities, PlayerActions } from "../../../lib/constants";
 
 const dispatch = jest.fn();
 
@@ -165,7 +165,7 @@ describe("Button clicks", () => {
     expect(fold).toHaveBeenCalledWith("player1", dispatch);
     expect(setLastAction).toHaveBeenCalled();
     expect(setLastAction).toHaveBeenCalledTimes(1);
-    expect(setLastAction).toHaveBeenCalledWith(0, "FOLD", dispatch);
+    expect(setLastAction).toHaveBeenCalledWith(0, PlayerActions.fold, dispatch);
 
     // Sends Fold to the backend
     expect(sendMessage).toHaveBeenCalled();
@@ -241,7 +241,7 @@ describe("Button clicks", () => {
     expect(bet).toHaveBeenCalledWith("player1", 100, state, dispatch);
     expect(setLastAction).toHaveBeenCalled();
     expect(setLastAction).toHaveBeenCalledTimes(1);
-    expect(setLastAction).toHaveBeenCalledWith(0, "CALL", dispatch);
+    expect(setLastAction).toHaveBeenCalledWith(0, PlayerActions.call, dispatch);
 
     // Sends Call to the backend
     expect(sendMessage).toHaveBeenCalled();
@@ -284,7 +284,11 @@ describe("Button clicks", () => {
     expect(bet).toHaveBeenCalledWith("player1", 50, state, dispatch);
     expect(setLastAction).toHaveBeenCalled();
     expect(setLastAction).toHaveBeenCalledTimes(1);
-    expect(setLastAction).toHaveBeenCalledWith(0, "RAISE", dispatch);
+    expect(setLastAction).toHaveBeenCalledWith(
+      0,
+      PlayerActions.raise,
+      dispatch
+    );
 
     // Sends Raise to the backend
     expect(sendMessage).toHaveBeenCalled();
@@ -327,7 +331,11 @@ describe("Button clicks", () => {
     expect(bet).toHaveBeenCalledWith("player1", 200, state, dispatch);
     expect(setLastAction).toHaveBeenCalled();
     expect(setLastAction).toHaveBeenCalledTimes(1);
-    expect(setLastAction).toHaveBeenCalledWith(0, "ALL-IN", dispatch);
+    expect(setLastAction).toHaveBeenCalledWith(
+      0,
+      PlayerActions.allIn,
+      dispatch
+    );
 
     // Sends All-In to the backend
     expect(sendMessage).toHaveBeenCalled();

--- a/src/components/Controls/__tests__/Controls.test.js
+++ b/src/components/Controls/__tests__/Controls.test.js
@@ -129,8 +129,9 @@ describe("Button clicks", () => {
   jest.spyOn(actions, "sendMessage");
   jest.spyOn(actions, "showControls");
   jest.spyOn(actions, "bet");
+  jest.spyOn(actions, "setLastAction");
 
-  const { bet, fold, sendMessage, showControls } = actions;
+  const { bet, fold, sendMessage, setLastAction, showControls } = actions;
 
   test("handles Fold button when clicked", () => {
     const state = testState;
@@ -146,6 +147,9 @@ describe("Button clicks", () => {
     expect(fold).toHaveBeenCalled();
     expect(fold).toHaveBeenCalledTimes(1);
     expect(fold).toHaveBeenCalledWith("player1", expect.anything());
+    expect(setLastAction).toHaveBeenCalled();
+    expect(setLastAction).toHaveBeenCalledTimes(1);
+    expect(setLastAction).toHaveBeenCalledWith(0, "FOLD", expect.anything());
 
     // Sends Fold to the backend
     expect(sendMessage).toHaveBeenCalled();
@@ -172,6 +176,11 @@ describe("Button clicks", () => {
     const wrapper = buildWrapper(state);
 
     wrapper.find(`[data-test="table-controls-check-button"]`).simulate("click");
+
+    // Send Check to the GUI
+    expect(setLastAction).toHaveBeenCalled();
+    expect(setLastAction).toHaveBeenCalledTimes(1);
+    expect(setLastAction).toHaveBeenCalledWith(0, "CHECK", expect.anything());
 
     // Sends Check to the backend
     expect(sendMessage).toHaveBeenCalled();
@@ -205,6 +214,9 @@ describe("Button clicks", () => {
     expect(bet).toHaveBeenCalled();
     expect(bet).toHaveBeenCalledTimes(1);
     expect(bet).toHaveBeenCalledWith("player1", 100, state, expect.anything());
+    expect(setLastAction).toHaveBeenCalled();
+    expect(setLastAction).toHaveBeenCalledTimes(1);
+    expect(setLastAction).toHaveBeenCalledWith(0, "CALL", expect.anything());
 
     // Sends Call to the backend
     expect(sendMessage).toHaveBeenCalled();
@@ -241,6 +253,9 @@ describe("Button clicks", () => {
     expect(bet).toHaveBeenCalled();
     expect(bet).toHaveBeenCalledTimes(1);
     expect(bet).toHaveBeenCalledWith("player1", 50, state, expect.anything());
+    expect(setLastAction).toHaveBeenCalled();
+    expect(setLastAction).toHaveBeenCalledTimes(1);
+    expect(setLastAction).toHaveBeenCalledWith(0, "RAISE", expect.anything());
 
     // Sends Raise to the backend
     expect(sendMessage).toHaveBeenCalled();
@@ -278,6 +293,9 @@ describe("Button clicks", () => {
     expect(bet).toHaveBeenCalled();
     expect(bet).toHaveBeenCalledTimes(1);
     expect(bet).toHaveBeenCalledWith("player1", 200, state, expect.anything());
+    expect(setLastAction).toHaveBeenCalled();
+    expect(setLastAction).toHaveBeenCalledTimes(1);
+    expect(setLastAction).toHaveBeenCalledWith(0, "ALL-IN", expect.anything());
 
     // Sends All-In to the backend
     expect(sendMessage).toHaveBeenCalled();

--- a/src/components/Controls/__tests__/Controls.test.js
+++ b/src/components/Controls/__tests__/Controls.test.js
@@ -128,8 +128,9 @@ describe("Button clicks", () => {
   jest.spyOn(actions, "fold");
   jest.spyOn(actions, "sendMessage");
   jest.spyOn(actions, "showControls");
+  jest.spyOn(actions, "bet");
 
-  const { fold, sendMessage, showControls } = actions;
+  const { bet, fold, sendMessage, showControls } = actions;
 
   test("handles Fold button when clicked", () => {
     const state = testState;
@@ -177,6 +178,42 @@ describe("Button clicks", () => {
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(sendMessage).toHaveBeenCalledWith(
       expect.objectContaining({ possibilities: [Possibilities.check] }),
+      "player1",
+      state,
+      expect.anything()
+    );
+
+    // Hides the Controls
+    expect(showControls).toHaveBeenCalled();
+    expect(showControls).toHaveBeenCalledTimes(1);
+    expect(showControls).toHaveBeenCalledWith(false, expect.anything());
+  });
+
+  test("handles Call button when clicked", () => {
+    const state = testState;
+    state.showControls = true;
+    state.userSeat = "player1";
+    state.controls.canCheck = false;
+    state.toCall = 100;
+    state.players.player1.betAmount = 0;
+
+    const wrapper = buildWrapper(state);
+
+    wrapper.find(`[data-test="table-controls-call-button"]`).simulate("click");
+
+    // Sends fold to the GUI
+    expect(bet).toHaveBeenCalled();
+    expect(bet).toHaveBeenCalledTimes(1);
+    expect(bet).toHaveBeenCalledWith("player1", 100, state, expect.anything());
+
+    // Sends call to the backend
+    expect(sendMessage).toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        possibilities: [Possibilities.call],
+        bet_amount: 100
+      }),
       "player1",
       state,
       expect.anything()

--- a/src/components/Controls/__tests__/Controls.test.js
+++ b/src/components/Controls/__tests__/Controls.test.js
@@ -142,12 +142,12 @@ describe("Button clicks", () => {
 
     wrapper.find(`[data-test="table-controls-fold-button"]`).simulate("click");
 
-    // Sends fold to the GUI
+    // Sends Fold to the GUI
     expect(fold).toHaveBeenCalled();
     expect(fold).toHaveBeenCalledTimes(1);
     expect(fold).toHaveBeenCalledWith("player1", expect.anything());
 
-    // Sends fold to the backend
+    // Sends Fold to the backend
     expect(sendMessage).toHaveBeenCalled();
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(sendMessage).toHaveBeenCalledWith(
@@ -173,7 +173,7 @@ describe("Button clicks", () => {
 
     wrapper.find(`[data-test="table-controls-check-button"]`).simulate("click");
 
-    // Sends fold to the backend
+    // Sends Check to the backend
     expect(sendMessage).toHaveBeenCalled();
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(sendMessage).toHaveBeenCalledWith(
@@ -201,12 +201,12 @@ describe("Button clicks", () => {
 
     wrapper.find(`[data-test="table-controls-call-button"]`).simulate("click");
 
-    // Sends fold to the GUI
+    // Sends Call to the GUI
     expect(bet).toHaveBeenCalled();
     expect(bet).toHaveBeenCalledTimes(1);
     expect(bet).toHaveBeenCalledWith("player1", 100, state, expect.anything());
 
-    // Sends call to the backend
+    // Sends Call to the backend
     expect(sendMessage).toHaveBeenCalled();
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(sendMessage).toHaveBeenCalledWith(
@@ -237,12 +237,12 @@ describe("Button clicks", () => {
 
     wrapper.find(`[data-test="table-controls-raise-button"]`).simulate("click");
 
-    // Sends fold to the GUI
+    // Sends Raise to the GUI
     expect(bet).toHaveBeenCalled();
     expect(bet).toHaveBeenCalledTimes(1);
     expect(bet).toHaveBeenCalledWith("player1", 50, state, expect.anything());
 
-    // Sends call to the backend
+    // Sends Raise to the backend
     expect(sendMessage).toHaveBeenCalled();
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(sendMessage).toHaveBeenCalledWith(
@@ -261,7 +261,7 @@ describe("Button clicks", () => {
     expect(showControls).toHaveBeenCalledWith(false, expect.anything());
   });
 
-  test("handles AllIn button when clicked", () => {
+  test("handles All-In button when clicked", () => {
     const state = testState;
     state.controls.showControls = true;
     state.userSeat = "player1";
@@ -274,12 +274,12 @@ describe("Button clicks", () => {
 
     wrapper.find(`[data-test="table-controls-raise-button"]`).simulate("click");
 
-    // Sends fold to the GUI
+    // Sends All-In to the GUI
     expect(bet).toHaveBeenCalled();
     expect(bet).toHaveBeenCalledTimes(1);
     expect(bet).toHaveBeenCalledWith("player1", 200, state, expect.anything());
 
-    // Sends call to the backend
+    // Sends All-In to the backend
     expect(sendMessage).toHaveBeenCalled();
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(sendMessage).toHaveBeenCalledWith(

--- a/src/components/Controls/__tests__/Controls.test.js
+++ b/src/components/Controls/__tests__/Controls.test.js
@@ -6,11 +6,12 @@ import testState from "../../../store/testState";
 import * as actions from "../../../store/actions";
 import { Possibilities } from "../../../lib/constants";
 
-const buildWrapper = stateToTest => {
-  const dispatch = jest.fn();
+const dispatch = jest.fn();
+
+const buildWrapper = (dispatch, state) => {
   return mount(
     <DispatchContext.Provider value={dispatch}>
-      <StateContext.Provider value={stateToTest}>
+      <StateContext.Provider value={state}>
         <Controls />
       </StateContext.Provider>
     </DispatchContext.Provider>
@@ -20,7 +21,7 @@ const buildWrapper = stateToTest => {
 describe("Controls", () => {
   test("displays all the controls by default", () => {
     const state = { ...testState };
-    const wrapper = buildWrapper(state);
+    const wrapper = buildWrapper(dispatch, state);
 
     expect(
       wrapper.find(`[data-test="table-controls-half-pot-button"]`)
@@ -50,7 +51,7 @@ describe("Controls", () => {
       controls: { ...testState.controls, canCheck: false }
     };
 
-    const wrapper = buildWrapper(state);
+    const wrapper = buildWrapper(dispatch, state);
 
     expect(
       wrapper.find(`[data-test="table-controls-call-button"]`)
@@ -66,7 +67,7 @@ describe("Controls", () => {
       minRaiseTo: 100,
       controls: { ...testState.controls, canRaise: true }
     };
-    const wrapper = buildWrapper(state);
+    const wrapper = buildWrapper(dispatch, state);
 
     expect(
       wrapper.find(`[data-test="table-controls-raise-button"]`)
@@ -82,7 +83,7 @@ describe("Controls", () => {
       toCall: 100,
       controls: { ...testState.controls, canCheck: true }
     };
-    const wrapper = buildWrapper(state);
+    const wrapper = buildWrapper(dispatch, state);
 
     expect(
       wrapper.find(`[data-test="table-controls-check-button"]`)
@@ -97,7 +98,7 @@ describe("Controls", () => {
       ...testState,
       controls: { ...testState.controls, canRaise: false }
     };
-    const wrapper = buildWrapper(state);
+    const wrapper = buildWrapper(dispatch, state);
 
     expect(
       wrapper.find(`[data-test="table-controls-raise-button"]`)
@@ -112,7 +113,7 @@ describe("Controls", () => {
       minRaiseTo: 300,
       controls: { ...testState.controls, canRaise: true }
     };
-    let wrapper = buildWrapper(state);
+    let wrapper = buildWrapper(dispatch, state);
 
     expect(
       wrapper.find(`[data-test="table-controls-raise-button"]`)
@@ -123,7 +124,7 @@ describe("Controls", () => {
 
     // Minimum raise is equals the player's stack
     state.minRaiseTo = 200;
-    wrapper = buildWrapper(state);
+    wrapper = buildWrapper(dispatch, state);
 
     expect(
       wrapper.find(`[data-test="table-controls-raise-button"]`)
@@ -154,17 +155,17 @@ describe("Button clicks", () => {
       }
     };
 
-    const wrapper = buildWrapper(state);
+    const wrapper = buildWrapper(dispatch, state);
 
     wrapper.find(`[data-test="table-controls-fold-button"]`).simulate("click");
 
     // Sends Fold to the GUI
     expect(fold).toHaveBeenCalled();
     expect(fold).toHaveBeenCalledTimes(1);
-    expect(fold).toHaveBeenCalledWith("player1", expect.anything());
+    expect(fold).toHaveBeenCalledWith("player1", dispatch);
     expect(setLastAction).toHaveBeenCalled();
     expect(setLastAction).toHaveBeenCalledTimes(1);
-    expect(setLastAction).toHaveBeenCalledWith(0, "FOLD", expect.anything());
+    expect(setLastAction).toHaveBeenCalledWith(0, "FOLD", dispatch);
 
     // Sends Fold to the backend
     expect(sendMessage).toHaveBeenCalled();
@@ -173,13 +174,13 @@ describe("Button clicks", () => {
       expect.objectContaining({ possibilities: [Possibilities.fold] }),
       "player1",
       state,
-      expect.anything()
+      dispatch
     );
 
     // Hides the Controls
     expect(showControls).toHaveBeenCalled();
     expect(showControls).toHaveBeenCalledTimes(1);
-    expect(showControls).toHaveBeenCalledWith(false, expect.anything());
+    expect(showControls).toHaveBeenCalledWith(false, dispatch);
   });
 
   test("handles Check button when clicked", () => {
@@ -193,14 +194,14 @@ describe("Button clicks", () => {
       }
     };
 
-    const wrapper = buildWrapper(state);
+    const wrapper = buildWrapper(dispatch, state);
 
     wrapper.find(`[data-test="table-controls-check-button"]`).simulate("click");
 
     // Send Check to the GUI
     expect(setLastAction).toHaveBeenCalled();
     expect(setLastAction).toHaveBeenCalledTimes(1);
-    expect(setLastAction).toHaveBeenCalledWith(0, "CHECK", expect.anything());
+    expect(setLastAction).toHaveBeenCalledWith(0, "CHECK", dispatch);
 
     // Sends Check to the backend
     expect(sendMessage).toHaveBeenCalled();
@@ -209,13 +210,13 @@ describe("Button clicks", () => {
       expect.objectContaining({ possibilities: [Possibilities.check] }),
       "player1",
       state,
-      expect.anything()
+      dispatch
     );
 
     // Hides the Controls
     expect(showControls).toHaveBeenCalled();
     expect(showControls).toHaveBeenCalledTimes(1);
-    expect(showControls).toHaveBeenCalledWith(false, expect.anything());
+    expect(showControls).toHaveBeenCalledWith(false, dispatch);
   });
 
   test("handles Call button when clicked", () => {
@@ -230,17 +231,17 @@ describe("Button clicks", () => {
       toCall: 100
     };
 
-    const wrapper = buildWrapper(state);
+    const wrapper = buildWrapper(dispatch, state);
 
     wrapper.find(`[data-test="table-controls-call-button"]`).simulate("click");
 
     // Sends Call to the GUI
     expect(bet).toHaveBeenCalled();
     expect(bet).toHaveBeenCalledTimes(1);
-    expect(bet).toHaveBeenCalledWith("player1", 100, state, expect.anything());
+    expect(bet).toHaveBeenCalledWith("player1", 100, state, dispatch);
     expect(setLastAction).toHaveBeenCalled();
     expect(setLastAction).toHaveBeenCalledTimes(1);
-    expect(setLastAction).toHaveBeenCalledWith(0, "CALL", expect.anything());
+    expect(setLastAction).toHaveBeenCalledWith(0, "CALL", dispatch);
 
     // Sends Call to the backend
     expect(sendMessage).toHaveBeenCalled();
@@ -252,13 +253,13 @@ describe("Button clicks", () => {
       }),
       "player1",
       state,
-      expect.anything()
+      dispatch
     );
 
     // Hides the Controls
     expect(showControls).toHaveBeenCalled();
     expect(showControls).toHaveBeenCalledTimes(1);
-    expect(showControls).toHaveBeenCalledWith(false, expect.anything());
+    expect(showControls).toHaveBeenCalledWith(false, dispatch);
   });
 
   test("handles Raise button when clicked", () => {
@@ -273,17 +274,17 @@ describe("Button clicks", () => {
       minRaiseTo: 50
     };
 
-    const wrapper = buildWrapper(state);
+    const wrapper = buildWrapper(dispatch, state);
 
     wrapper.find(`[data-test="table-controls-raise-button"]`).simulate("click");
 
     // Sends Raise to the GUI
     expect(bet).toHaveBeenCalled();
     expect(bet).toHaveBeenCalledTimes(1);
-    expect(bet).toHaveBeenCalledWith("player1", 50, state, expect.anything());
+    expect(bet).toHaveBeenCalledWith("player1", 50, state, dispatch);
     expect(setLastAction).toHaveBeenCalled();
     expect(setLastAction).toHaveBeenCalledTimes(1);
-    expect(setLastAction).toHaveBeenCalledWith(0, "RAISE", expect.anything());
+    expect(setLastAction).toHaveBeenCalledWith(0, "RAISE", dispatch);
 
     // Sends Raise to the backend
     expect(sendMessage).toHaveBeenCalled();
@@ -295,13 +296,13 @@ describe("Button clicks", () => {
       }),
       "player1",
       state,
-      expect.anything()
+      dispatch
     );
 
     // Hides the Controls
     expect(showControls).toHaveBeenCalled();
     expect(showControls).toHaveBeenCalledTimes(1);
-    expect(showControls).toHaveBeenCalledWith(false, expect.anything());
+    expect(showControls).toHaveBeenCalledWith(false, dispatch);
   });
 
   test("handles All-In button when clicked", () => {
@@ -316,17 +317,17 @@ describe("Button clicks", () => {
       minRaiseTo: 200
     };
 
-    const wrapper = buildWrapper(state);
+    const wrapper = buildWrapper(dispatch, state);
 
     wrapper.find(`[data-test="table-controls-raise-button"]`).simulate("click");
 
     // Sends All-In to the GUI
     expect(bet).toHaveBeenCalled();
     expect(bet).toHaveBeenCalledTimes(1);
-    expect(bet).toHaveBeenCalledWith("player1", 200, state, expect.anything());
+    expect(bet).toHaveBeenCalledWith("player1", 200, state, dispatch);
     expect(setLastAction).toHaveBeenCalled();
     expect(setLastAction).toHaveBeenCalledTimes(1);
-    expect(setLastAction).toHaveBeenCalledWith(0, "ALL-IN", expect.anything());
+    expect(setLastAction).toHaveBeenCalledWith(0, "ALL-IN", dispatch);
 
     // Sends All-In to the backend
     expect(sendMessage).toHaveBeenCalled();
@@ -338,12 +339,12 @@ describe("Button clicks", () => {
       }),
       "player1",
       state,
-      expect.anything()
+      dispatch
     );
 
     // Hides the Controls
     expect(showControls).toHaveBeenCalled();
     expect(showControls).toHaveBeenCalledTimes(1);
-    expect(showControls).toHaveBeenCalledWith(false, expect.anything());
+    expect(showControls).toHaveBeenCalledWith(false, dispatch);
   });
 });

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -7,3 +7,13 @@ export enum Possibilities {
   "allIn" = 6,
   "fold" = 7
 }
+
+export enum PlayerActions {
+  fold = "FOLD",
+  check = "CHDCK",
+  raise = "RAISE",
+  call = "CALL",
+  smallBlind = "SMALL BLIND",
+  bigBlind = "BIG BLIND",
+  allIn = "ALL-IN"
+}


### PR DESCRIPTION
This PR fixes #61 by evaluating the button click based on the `Possibilities` enum, instead of using logic. I also added some tests. I wasn't sure how to mock `dispatch`, so I used `expect.anything()`. I am also not fully sure how to make the repeating tests for hiding the controls more DRY. 