### PR TITLE
Add timer feature

### DIFF
--- a/src/components/Controls/Controls.tsx
+++ b/src/components/Controls/Controls.tsx
@@ -9,6 +9,7 @@ import {
   fold,
   log,
   sendMessage,
+  setActivePlayer,
   setLastAction,
   showControls
 } from "../../store/actions";
@@ -108,8 +109,13 @@ const Controls: React.FunctionComponent = () => {
 
     // Hide Controls
     showControls(false, dispatch);
+
+    // Disable active player highlighting
+    setActivePlayer(null, dispatch);
+
     // Update the player's name with the last action
     setLastAction(nextAction.playerid, lastAction, dispatch);
+
     // Send the message to the back-end
     nextAction.possibilities = [action];
     sendMessage(nextAction, userSeat, state, dispatch);

--- a/src/components/Game/onMessage.ts
+++ b/src/components/Game/onMessage.ts
@@ -267,11 +267,13 @@ export const onMessage_player = (
         case "check":
           setLastAction(guiPlayer, "check", dispatch);
           addToHandHistory(`Player${guiPlayer + 1} checks.`, dispatch);
+          setActivePlayer(null, dispatch);
           break;
         case "call":
           bet(guiPlayer, betAmount, state, dispatch);
           setLastAction(guiPlayer, "call", dispatch);
           addToHandHistory(`Player${guiPlayer + 1} calls.`, dispatch);
+          setActivePlayer(null, dispatch);
           break;
         case "raise":
           bet(guiPlayer, betAmount, state, dispatch);
@@ -280,11 +282,13 @@ export const onMessage_player = (
             `Player${guiPlayer + 1} raises to ${betAmount}.`,
             dispatch
           );
+          setActivePlayer(null, dispatch);
           break;
         case "fold":
           fold(`player${guiPlayer + 1}`, dispatch);
           setLastAction(guiPlayer, "fold", dispatch);
           addToHandHistory(`Player${guiPlayer + 1} folds.`, dispatch);
+          setActivePlayer(null, dispatch);
           break;
 
         case "allin":
@@ -295,6 +299,7 @@ export const onMessage_player = (
             `Player${guiPlayer + 1} is All-In with ${betAmount}.`,
             dispatch
           );
+          setActivePlayer(null, dispatch);
           break;
 
         default:

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -214,6 +214,7 @@ const Player: React.FunctionComponent<IProps> = ({
           setSeatMessage("SITTING...");
         }
       }}
+      data-test={`player-widget-${seat}`}
     >
       {cardsDealt && showCards && hasCards && (
         <CardsWrapper>

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -278,6 +278,7 @@ const Player: React.FunctionComponent<IProps> = ({
             transition: ${transitionSpeed}s;
             width: 6.75rem;
           `}
+          data-test="player-highlight"
         >
           <div
             css={css`
@@ -286,6 +287,7 @@ const Player: React.FunctionComponent<IProps> = ({
               width: ${(secondsLeft / timeAllowance) * 100}%;
               transition: ${transitionSpeed}s;
             `}
+            data-test="player-timer-bar"
           />
         </div>
       )}

--- a/src/components/Player/__tests__/Player.test.js
+++ b/src/components/Player/__tests__/Player.test.js
@@ -2,27 +2,80 @@ import React from "react";
 import { mount } from "enzyme";
 import { StateContext, DispatchContext } from "../../../store/context";
 import testState from "../../../store/testState";
+import * as actions from "../../../store/actions";
 import Player from "../Player";
 
 const dispatch = jest.fn();
 
-const buildWrapper = (dispatch, state) => {
+const buildWrapper = (props, dispatch, state) => {
   return mount(
     <DispatchContext.Provider value={dispatch}>
       <StateContext.Provider value={state}>
-        <Player connected chips={1000} seat="player1" isActive />
+        <Player
+          chips={props.chips}
+          connected={props.connected}
+          hasCards={props.hasCards}
+          isActive={props.isActive}
+          playerCards={props.playerCards}
+          seat={props.seat}
+          showCards={props.showCards}
+          winner={props.winner}
+        />
       </StateContext.Provider>
     </DispatchContext.Provider>
   );
 };
 
+// Props
+const defaultProps = {
+  chips: 200,
+  connected: true,
+  hasCards: true,
+  isActive: true,
+  playerCards: ["Ac", "Ad"],
+  seat: "player1",
+  showCards: false,
+  winner: "player1"
+};
+
+const { seat } = defaultProps;
+
+// Action Spies
+jest.spyOn(actions, "playerJoin");
+jest.spyOn(actions, "playerJoin");
+const { playerJoin, setSeatMessage } = actions;
+
 describe("Player", () => {
+  test("joins when not conencted and clicked", () => {
+    const state = {
+      ...testState,
+      userSeat: "player1"
+    };
+    const wrapper = buildWrapper(
+      { ...defaultProps, connected: false },
+      dispatch,
+      state
+    );
+
+    const playerWidget = wrapper.find(
+      `div[data-test="player-widget-${defaultProps.seat}"]`
+    );
+
+    expect(playerWidget.exists()).toEqual(true);
+
+    playerWidget.simulate("click");
+
+    expect(playerJoin).toHaveBeenCalled();
+    expect(playerJoin).toHaveBeenCalledTimes(1);
+    expect(playerJoin).toHaveBeenCalledWith(seat, state, dispatch);
+  });
+
   test("is highlighted when active", () => {
     const state = {
       ...testState,
       userSeat: "player1"
     };
-    const wrapper = buildWrapper(dispatch, state);
+    const wrapper = buildWrapper(defaultProps, dispatch, state);
 
     expect(wrapper.find(`[data-test="player-highlight"]`).exists()).toEqual(
       true
@@ -34,7 +87,7 @@ describe("Player", () => {
       ...testState,
       userSeat: "player1"
     };
-    const wrapper = buildWrapper(dispatch, state);
+    const wrapper = buildWrapper(defaultProps, dispatch, state);
 
     expect(wrapper.find(`[data-test="player-timer-bar"]`).exists()).toEqual(
       true

--- a/src/components/Player/__tests__/Player.test.js
+++ b/src/components/Player/__tests__/Player.test.js
@@ -1,0 +1,43 @@
+import React from "react";
+import { mount } from "enzyme";
+import { StateContext, DispatchContext } from "../../../store/context";
+import testState from "../../../store/testState";
+import Player from "../Player";
+
+const dispatch = jest.fn();
+
+const buildWrapper = (dispatch, state) => {
+  return mount(
+    <DispatchContext.Provider value={dispatch}>
+      <StateContext.Provider value={state}>
+        <Player connected chips={1000} seat="player1" isActive />
+      </StateContext.Provider>
+    </DispatchContext.Provider>
+  );
+};
+
+describe("Player", () => {
+  test("is highlighted when active", () => {
+    const state = {
+      ...testState,
+      userSeat: "player1"
+    };
+    const wrapper = buildWrapper(dispatch, state);
+
+    expect(wrapper.find(`[data-test="player-highlight"]`).exists()).toEqual(
+      true
+    );
+  });
+
+  test("is dispalying the timer when active", () => {
+    const state = {
+      ...testState,
+      userSeat: "player1"
+    };
+    const wrapper = buildWrapper(dispatch, state);
+
+    expect(wrapper.find(`[data-test="player-timer-bar"]`).exists()).toEqual(
+      true
+    );
+  });
+});

--- a/src/components/Player/__tests__/Player.test.js
+++ b/src/components/Player/__tests__/Player.test.js
@@ -32,7 +32,7 @@ const defaultProps = {
   connected: true,
   hasCards: true,
   isActive: true,
-  playerCards: ["Ac", "Ad"],
+  playerCards: [],
   seat: "player1",
   showCards: false,
   winner: "player1"
@@ -68,6 +68,49 @@ describe("Player", () => {
     expect(playerJoin).toHaveBeenCalled();
     expect(playerJoin).toHaveBeenCalledTimes(1);
     expect(playerJoin).toHaveBeenCalledWith(seat, state, dispatch);
+  });
+
+  test("shows the facedown cards", () => {
+    const state = {
+      ...testState,
+      userSeat: "player1"
+    };
+    const wrapper = buildWrapper(defaultProps, dispatch, state);
+
+    expect(wrapper.find(`CardFaceDown`).exists()).toEqual(true);
+    expect(wrapper.find(`CardFaceDown`)).toHaveLength(2);
+  });
+
+  test("shows the player cards", () => {
+    const state = {
+      ...testState,
+      cardsDealt: true,
+      userSeat: "player1",
+      holeCards: ["Ac", "Ad"]
+    };
+    const wrapper = buildWrapper(
+      { ...defaultProps, showCards: true },
+      dispatch,
+      state
+    );
+
+    expect(wrapper.find(`CardsWrapper`).exists()).toEqual(true);
+    expect(wrapper.find(`Card`).exists()).toEqual(true);
+    expect(wrapper.find(`Card`)).toHaveLength(2);
+    expect(
+      wrapper
+        .find(`Card`)
+        .at(0)
+        .html()
+        .includes(`Ac`)
+    ).toBe(true);
+    expect(
+      wrapper
+        .find(`Card`)
+        .at(1)
+        .html()
+        .includes(`Ad`)
+    ).toBe(true);
   });
 
   test("is highlighted when active", () => {


### PR DESCRIPTION
This PR fixes #17 by adding a timer feature. 

The point of the timer is to limit the time each player has to act, making sure that the game is not stuck. When the time is up, the player is taking a forced check or fold action based on whether check is available. Here is a video demonstrating the feature: https://share.getcloudapp.com/2NurB55E

I have added some basic testing, and added some additional tests for the Player widget while I was at it. However, I wasn't sure how to test `useState` and `useEffect` hooks which handle the timer and the automatic folding, so these are not tested currently. Any insight on how I could test for them would be appreciated.