### PR TITLE
Fix showdown bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4388,6 +4388,11 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
+    "deep-diff": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-1.0.2.tgz",
+      "integrity": "sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg=="
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@typescript-eslint/parser": "^1.13.0",
     "babel-jest": "^24.9.0",
     "cssnano": "^4.1.10",
+    "deep-diff": "^1.0.2",
     "emotion": "^10.0.9",
     "normalize.css": "^8.0.1",
     "rc-slider": "^8.6.13",

--- a/src/components/Game/onMessage.ts
+++ b/src/components/Game/onMessage.ts
@@ -432,7 +432,6 @@ export const onMessage_player = (
 
     case "reset":
       setTimeout(() => {
-        setUserSeat(null, dispatch);
         nextHand(state, dispatch);
         playerJoin(player, state, dispatch);
       }, 3000);

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,5 +1,6 @@
 import { css } from "@emotion/core";
-import { useReducer, useEffect } from "react";
+import { useReducer, useEffect, useState } from "react";
+import diff from "deep-diff";
 import theme from "../../styles/theme";
 import reducer from "../../store/reducer";
 import { StateContext, DispatchContext } from "../../store/context";
@@ -22,6 +23,7 @@ import LogBox from "../LogBox";
 // This is the current Main component
 
 const Table: React.FunctionComponent = () => {
+  const [previousState, setPreviousState] = useState();
   const [state, dispatch]: [IState, Function] = useReducer(
     reducer,
     initialState
@@ -46,11 +48,13 @@ const Table: React.FunctionComponent = () => {
     winner
   } = state;
 
-  // For debugging purposes log the state when it changes
-  // useEffect(() => {
-  //   console.log("The state has changed");
-  //   console.log(state);
-  // }, [state]);
+  // For debugging purposes log the difference betweeen the last and current state
+  useEffect(() => {
+    const difference = diff(previousState, state);
+    difference && difference.push(state);
+    console.log(difference);
+    setPreviousState(state);
+  }, [state]);
 
   return (
     <DispatchContext.Provider value={dispatch}>

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -133,29 +133,29 @@ const reducer: Function = (state: IState, action: IAction): object => {
       };
     }
     case "resetTurn": {
+      console.log("RESET TURN");
       return {
         ...state,
         chipsCollected: false,
         minRaiseTo: action.payload,
-        isShowDown: false,
+
         players: {
           ...state.players,
           player1: {
             ...state.players.player1,
             isBetting: false,
-            betAmount: 0,
-            playerCards: []
+            betAmount: 0
           },
           player2: {
             ...state.players.player2,
             isBetting: false,
-            betAmount: 0,
-            playerCards: []
+            betAmount: 0
           }
         }
       };
     }
     case "resetHand": {
+      console.log("RESET HAND");
       return {
         ...state,
         boardCards: [],


### PR DESCRIPTION
This PR fixes #65 by removing some redundant state changes that caused the`playerCards` array to become empty before it was supposed to.

I have also set up state difference logging for debugging purposes.