### PR TITLE
Update logic to work with split pots

### DIFF
--- a/src/components/Chips/Bet.tsx
+++ b/src/components/Chips/Bet.tsx
@@ -32,6 +32,7 @@ const Bet: React.FunctionComponent<IProps> = ({
 
         transition-delay: 0.4s;
       `}
+      data-test={"bet"}
     >
       <span
         css={css`

--- a/src/components/Game/__tests__/onMessage.test.ts
+++ b/src/components/Game/__tests__/onMessage.test.ts
@@ -217,7 +217,7 @@ describe("handHistory", () => {
 
     expect(addToHandHistorySpy).toHaveBeenCalledTimes(1);
     expect(addToHandHistorySpy).toHaveBeenCalledWith(
-      `Player2 is All-In with 1000.`,
+      `Player2 is All-In with 1,000.`,
       dispatch
     );
   });
@@ -249,7 +249,25 @@ describe("handHistory", () => {
 
     expect(addToHandHistorySpy).toHaveBeenCalledTimes(1);
     expect(addToHandHistorySpy).toHaveBeenCalledWith(
-      `Player1 wins 1000.`,
+      `Player1 wins 1,000.`,
+      dispatch
+    );
+  });
+
+  test("logs the winner and the win amount in case of split pot and two winners", () => {
+    receiveMessage(
+      {
+        method: "finalInfo",
+        showInfo: { boardCardInfo: ["10c", "Ad", "Ac", null, null] },
+        win_amount: 1000, //eslint-disable-line @typescript-eslint/camelcase
+        winners: [0, 1]
+      },
+      0
+    );
+
+    expect(addToHandHistorySpy).toHaveBeenCalledTimes(1);
+    expect(addToHandHistorySpy).toHaveBeenCalledWith(
+      `The pot is split between player1 and player2. Each player wins 1,000.`,
       dispatch
     );
   });

--- a/src/components/Game/onMessage.ts
+++ b/src/components/Game/onMessage.ts
@@ -341,8 +341,9 @@ export const onMessage_player = (
       const isShowDown = boardCardInfo.every(x => x !== null);
 
       const handleWinner = (): void => {
-        setWinner(message.winners[0], message.win_amount, state, dispatch);
+        setWinner(message.winners, message.win_amount, state, dispatch);
         addToHandHistory(
+          // TODO: Fix the log
           `Player${message.winners[0] + 1} wins ${message.win_amount}.`,
           dispatch
         );
@@ -467,6 +468,6 @@ export const onMessage_player = (
       break;
 
     default:
-    // sendMessage(message, "dcv", state, dispatch);
+      sendMessage(message, "dcv", state, dispatch);
   }
 };

--- a/src/components/Game/onMessage.ts
+++ b/src/components/Game/onMessage.ts
@@ -33,6 +33,7 @@ import playerStringToId from "../../lib/playerStringToId";
 import numberWithCommas from "../../lib/numberWithCommas";
 import { IState } from "../../store/initialState";
 import playerIdToString from "../../lib/playerIdToString";
+import arrayListToSentence from "../../lib/arrayListToSentence";
 import lowerCaseLastLetter from "../../lib/lowerCaseLastLetter";
 import sounds from "../../sounds/sounds";
 import { GameTurns } from "../../lib/constants";
@@ -339,14 +340,40 @@ export const onMessage_player = (
       let currentGameTurn = state.gameTurn;
       const boardCardInfo = message.showInfo.boardCardInfo;
       const isShowDown = boardCardInfo.every(x => x !== null);
+      const { winners, win_amount } = message; //eslint-disable-line @typescript-eslint/camelcase
+
+      // Log winners to hand history
+      const logWinners = (): void => {
+        // Log if there is a single winner
+        if (winners.length === 1) {
+          addToHandHistory(
+            `Player${winners[0] + 1} wins ${numberWithCommas(win_amount)}.`, //eslint-disable-line @typescript-eslint/camelcase
+            dispatch
+          );
+          // Log if the pot is split between multiple players
+        } else if (winners.length > 1 && winners.length < 10) {
+          const winnerList = arrayListToSentence(
+            winners.map(winner => `${playerIdToString(winner)}`)
+          );
+
+          addToHandHistory(
+            `The pot is split between ${winnerList}. Each player wins ${numberWithCommas(
+              win_amount
+            )}.`, //eslint-disable-line @typescript-eslint/camelcase
+            dispatch
+          );
+        }
+        // Else log an error in the console
+        else {
+          console.error(
+            "Incorrect winner ammount has been passed in to the log."
+          );
+        }
+      };
 
       const handleWinner = (): void => {
         setWinner(message.winners, message.win_amount, state, dispatch);
-        addToHandHistory(
-          // TODO: Fix the log
-          `Player${message.winners[0] + 1} wins ${message.win_amount}.`,
-          dispatch
-        );
+        logWinners();
       };
 
       // Log board cards when players go All-In

--- a/src/components/Game/onMessage.ts
+++ b/src/components/Game/onMessage.ts
@@ -27,7 +27,8 @@ import {
   updateGameTurn,
   updateStateValue,
   setBoardCards,
-  processControls
+  processControls,
+  updateMainPot
 } from "../../store/actions";
 import playerStringToId from "../../lib/playerStringToId";
 import numberWithCommas from "../../lib/numberWithCommas";
@@ -376,6 +377,7 @@ export const onMessage_player = (
       const handleWinner = (): void => {
         setWinner(message.winners, message.win_amount, state, dispatch);
         logWinners();
+        setTimeout(() => updateMainPot(win_amount, dispatch), 2000);
       };
 
       // Log board cards when players go All-In

--- a/src/components/Game/onMessage.ts
+++ b/src/components/Game/onMessage.ts
@@ -280,7 +280,9 @@ export const onMessage_player = (
             setToCall(betAmount, dispatch);
             setLastAction(guiPlayer, "all-in", dispatch);
             addToHandHistory(
-              `Player${guiPlayer + 1} is All-In with ${betAmount}.`,
+              `Player${guiPlayer + 1} is All-In with ${numberWithCommas(
+                betAmount
+              )}.`,
               dispatch
             );
             setActivePlayer(null, dispatch);

--- a/src/components/Table/MainPot.tsx
+++ b/src/components/Table/MainPot.tsx
@@ -1,4 +1,5 @@
 import { css } from "@emotion/core";
+import styled from "@emotion/styled";
 import { useEffect, useState } from "react";
 import { Bet } from "../Chips";
 import { GameTurns } from "../../lib/constants";
@@ -8,52 +9,71 @@ import { GameTurns } from "../../lib/constants";
 interface IProps {
   mainPot: number;
   gameTurn: number;
-  winner: string;
+  winners: string[];
 }
 
 const { showDown } = GameTurns;
 
+const winnerPotLocation = {
+  player1: {
+    left: "25rem",
+    top: "9.5rem"
+  },
+  player2: {
+    left: "27rem",
+    top: "14rem"
+  }
+};
+
 const MainPot: React.FunctionComponent<IProps> = ({
   mainPot,
   gameTurn,
-  winner
+  winners
 }) => {
-  const [winnerCoordinates, setWinnerCoordinates]: [
-    { left: number | string; top: string },
-    Function
-  ] = useState({
-    left: 0,
-    top: "19rem"
-  });
+  const potStyle = css`
+    display: flex;
+    justify-content: center;
+    left: 0;
+    margin: auto;
+    position: absolute;
+    right: 4rem;
+    top: 19rem;
+    transition-delay: 1s;
+    transition: 0.5s ease-out;
+  `;
 
-  // Temporarily way of determining the winner. Only works in heads up.
-  // TODO: Separate the logic for the winner selection
-
-  useEffect(() => {
-    if (gameTurn === showDown && winner) {
-      if (winner === "player1") {
-        setWinnerCoordinates({ left: "25rem", top: "9.5rem" });
-      } else if (winner === "player2") {
-        setWinnerCoordinates({ left: "27rem", top: "14rem" });
-      } else throw new Error("The winner is unclear");
-    }
-  }, [winner]);
+  const isWinnerSelect = gameTurn === showDown && winners;
 
   return (
-    <div
-      css={css`
-        position: absolute;
-        left: ${gameTurn === showDown ? winnerCoordinates.left : "0"};
-        right: 4rem;
-        margin: auto;
-        display: flex;
-        justify-content: center;
-        top: ${gameTurn === showDown ? winnerCoordinates.top : "19rem"};
-        transition: 0.5s ease-out;
-        transition-delay: 1s;
-      `}
-    >
-      <Bet betAmount={mainPot} />
+    <div>
+      {/* Regular pot */}
+      {!isWinnerSelect && (
+        <div
+          css={css`
+            ${potStyle}
+          `}
+        >
+          <Bet betAmount={mainPot} />
+        </div>
+      )}
+
+      {/* Winner Pot(s) */}
+      {isWinnerSelect &&
+        winners.map(player => {
+          return (
+            <div
+              css={css`
+          ${potStyle}
+          
+          left: ${winnerPotLocation[player].left};
+          top: ${winnerPotLocation[player].top};
+        `}
+              key={player}
+            >
+              <Bet betAmount={mainPot} />
+            </div>
+          );
+        })}
     </div>
   );
 };

--- a/src/components/Table/MainPot.tsx
+++ b/src/components/Table/MainPot.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { css } from "@emotion/core";
 import { Bet } from "../Chips";
 import { GameTurns } from "../../lib/constants";

--- a/src/components/Table/MainPot.tsx
+++ b/src/components/Table/MainPot.tsx
@@ -5,7 +5,7 @@ import { GameTurns } from "../../lib/constants";
 // This is the component that displays the main pot at the middle of table
 
 interface IProps {
-  mainPot: number;
+  pot: number[];
   gameTurn: number;
   winners: string[];
 }
@@ -25,7 +25,7 @@ const winnerPotLocation = {
 };
 
 const MainPot: React.FunctionComponent<IProps> = ({
-  mainPot,
+  pot,
   gameTurn,
   winners
 }) => {
@@ -51,7 +51,7 @@ const MainPot: React.FunctionComponent<IProps> = ({
 
   return (
     <div>
-      {winners.map(player => {
+      {winners.map((player, index) => {
         // Custom animation style for each winner to send each pot to the right location
         const animationStyle = css`
           animation: ${isWinnerSelectTurn &&
@@ -76,7 +76,7 @@ const MainPot: React.FunctionComponent<IProps> = ({
             `}
             key={player}
           >
-            <Bet betAmount={mainPot} />
+            <Bet betAmount={pot && pot[0]} />
           </div>
         );
       })}

--- a/src/components/Table/MainPot.tsx
+++ b/src/components/Table/MainPot.tsx
@@ -74,7 +74,8 @@ const MainPot: React.FunctionComponent<IProps> = ({
               ${potStyle}
               ${animationStyle}
             `}
-            key={player}
+            key={index}
+            data-test={`main-pot${player ? `-${player}` : ``}`}
           >
             <Bet betAmount={pot && pot[0]} />
           </div>

--- a/src/components/Table/MainPot.tsx
+++ b/src/components/Table/MainPot.tsx
@@ -1,6 +1,5 @@
-import { css } from "@emotion/core";
-import styled from "@emotion/styled";
 import { useEffect, useState } from "react";
+import { css } from "@emotion/core";
 import { Bet } from "../Chips";
 import { GameTurns } from "../../lib/constants";
 
@@ -14,13 +13,14 @@ interface IProps {
 
 const { showDown } = GameTurns;
 
+// Coordinates for where the winner's pot should be pushed
 const winnerPotLocation = {
   player1: {
     left: "25rem",
     top: "9.5rem"
   },
   player2: {
-    left: "27rem",
+    left: "30rem",
     top: "14rem"
   }
 };
@@ -30,50 +30,57 @@ const MainPot: React.FunctionComponent<IProps> = ({
   gameTurn,
   winners
 }) => {
+  const isWinnerSelectTurn = gameTurn === showDown && winners;
+
+  // Main Pot's position at the center of the screen
+  const { left, top } = {
+    left: 0,
+    top: "19rem"
+  };
+
+  // Shared pot style
   const potStyle = css`
     display: flex;
     justify-content: center;
-    left: 0;
+    left: ${left};
     margin: auto;
     position: absolute;
     right: 4rem;
-    top: 19rem;
-    transition-delay: 1s;
-    transition: 0.5s ease-out;
+    top: ${top};
+    animation-iteration-count: 1;
   `;
-
-  const isWinnerSelect = gameTurn === showDown && winners;
 
   return (
     <div>
-      {/* Regular pot */}
-      {!isWinnerSelect && (
-        <div
-          css={css`
-            ${potStyle}
-          `}
-        >
-          <Bet betAmount={mainPot} />
-        </div>
-      )}
+      {winners.map(player => {
+        // Custom animation style for each winner to send each pot to the right location
+        const animationStyle = css`
+          animation: ${isWinnerSelectTurn &&
+            `${`winnerSelect-${player}`} 0.5s ease-out 1s forwards`};
+          @keyframes ${`winnerSelect-${player}`} {
+            0% {
+              left: ${left};
+              top: ${top};
+            }
+            100% {
+              left: ${player && winnerPotLocation[player].left};
+              top: ${player && winnerPotLocation[player].top};
+            }
+          }
+        `;
 
-      {/* Winner Pot(s) */}
-      {isWinnerSelect &&
-        winners.map(player => {
-          return (
-            <div
-              css={css`
-          ${potStyle}
-          
-          left: ${winnerPotLocation[player].left};
-          top: ${winnerPotLocation[player].top};
-        `}
-              key={player}
-            >
-              <Bet betAmount={mainPot} />
-            </div>
-          );
-        })}
+        return (
+          <div
+            css={css`
+              ${potStyle}
+              ${animationStyle}
+            `}
+            key={player}
+          >
+            <Bet betAmount={mainPot} />
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -135,7 +135,7 @@ const Table: React.FunctionComponent = () => {
             </ChipGrid>
             {showMainPot && pot[0] !== 0 && (
               <MainPot
-                mainPot={pot[0]}
+                pot={pot}
                 gameTurn={state.gameTurn}
                 winners={state.winners}
               />

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -137,7 +137,7 @@ const Table: React.FunctionComponent = () => {
               <MainPot
                 mainPot={pot[0]}
                 gameTurn={state.gameTurn}
-                winner={state.winner}
+                winners={state.winners}
               />
             )}
             {showDealer && <Dealer dealer={`player${dealer + 1}`} />}

--- a/src/components/Table/__tests__/MainPot.test.js
+++ b/src/components/Table/__tests__/MainPot.test.js
@@ -1,0 +1,56 @@
+import { mount } from "enzyme";
+import { StateContext, DispatchContext } from "../../../store/context";
+import MainPot from "../MainPot";
+import testState from "../../../store/testState";
+import { GameTurns } from "../../../lib/constants";
+
+const dispatch = jest.fn();
+
+const buildWrapper = (dispatch, state) => {
+  return mount(
+    <DispatchContext.Provider value={dispatch}>
+      <StateContext.Provider value={state}>
+        <MainPot
+          pot={state.pot}
+          gameTurn={state.gameTurn}
+          winners={state.winners}
+        />
+      </StateContext.Provider>
+    </DispatchContext.Provider>
+  );
+};
+
+describe("MainPot", () => {
+  test("displays the main pot with the correct amount", () => {
+    const state = { ...testState, winners: [undefined], pot: [1268] };
+    const wrapper = buildWrapper(dispatch, state);
+
+    expect(wrapper.find(`div[data-test="main-pot"]`)).toHaveLength(1);
+    expect(wrapper.find(`div[data-test="main-pot-player1"]`)).toHaveLength(0);
+    expect(wrapper.find(`div[data-test="main-pot-player2"]`)).toHaveLength(0);
+    expect(
+      wrapper.find(`div[data-test="main-pot"] span[data-test="bet"]`).text()
+    ).toContain("1,268");
+  });
+
+  test("displays two pots for two players", () => {
+    const state = {
+      ...testState,
+      winners: ["player1", "player2"],
+      pot: [200],
+      gameTurn: GameTurns.showDownj
+    };
+    const wrapper = buildWrapper(dispatch, state);
+
+    expect(wrapper.find(`div[data-test="main-pot"]`)).toHaveLength(0);
+    expect(wrapper.find(`div[data-test="main-pot-player1"]`)).toHaveLength(1);
+    expect(wrapper.find(`div[data-test="main-pot-player2"]`)).toHaveLength(1);
+    expect(
+      wrapper
+        .find(`div[data-test="main-pot-player1"] span[data-test="bet"]`)
+        .text()
+    ).toContain("200");
+  });
+
+  // TODO: Add tests for the pots location
+});

--- a/src/lib/__tests__/arrayListToSentence.test.js
+++ b/src/lib/__tests__/arrayListToSentence.test.js
@@ -1,0 +1,58 @@
+import arrayListToSentence from "../arrayListToSentence";
+
+console.error = jest.fn();
+
+describe("Turns an array into a sentence string", () => {
+  test("Returns the correct string with two string elements", () => {
+    const array = ["Ad", "Kc"];
+    expect(arrayListToSentence(array)).toBe("Ad and Kc");
+  });
+  test("Returns the correct string with three string elements", () => {
+    const array = ["Ad", "Kc", "5d"];
+    expect(arrayListToSentence(array)).toBe("Ad, Kc and 5d");
+  });
+  test("Returns the correct string with both mixed and string elements", () => {
+    const array = ["Ad", 4, "5d", "Qd"];
+    expect(arrayListToSentence(array)).toBe("Ad, 4, 5d and Qd");
+  });
+  test("Returns the correct string with number elements", () => {
+    const array = [5, 6, 7];
+    expect(arrayListToSentence(array)).toBe("5, 6 and 7");
+  });
+  test("Returns the correct string with one element", () => {
+    const array = ["Ad"];
+    expect(arrayListToSentence(array)).toBe("Ad");
+  });
+  test("Logs an error to the console when the array is empty", () => {
+    const array = [];
+    arrayListToSentence(array);
+    expect(console.error).toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      "Can't convert empty array to a sentence."
+    );
+  });
+  test("Logs an error to the console when the array has undefined in it", () => {
+    const array = [undefined, "4"];
+    console.log(arrayListToSentence(array));
+    expect(console.error).toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      "Can only convert an array containing string or number elements"
+    );
+  });
+  test("Logs an error to the console when the array has null in it", () => {
+    const array = [null, "4"];
+    console.log(arrayListToSentence(array));
+    expect(console.error).toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      "Can only convert an array containing string or number elements"
+    );
+  });
+  test("Logs an error to the console when the array has boolean in it", () => {
+    const array = [true, "4"];
+    console.log(arrayListToSentence(array));
+    expect(console.error).toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      "Can only convert an array containing string or number elements"
+    );
+  });
+});

--- a/src/lib/arrayListToSentence.ts
+++ b/src/lib/arrayListToSentence.ts
@@ -1,0 +1,18 @@
+const isStringOrNumber = (element): boolean =>
+  typeof element === "string" || typeof element === "number";
+
+const arrayListToSentence = (array: string[] | number[]): string => {
+  if (array.length > 0) {
+    if (array.every(isStringOrNumber))
+      return array
+        .toString()
+        .replace(/,/g, ", ")
+        .replace(/, (?!.*,)/g, " and ");
+    else
+      console.error(
+        "Can only convert an array containing string or number elements"
+      );
+  } else console.error("Can't convert empty array to a sentence.");
+};
+
+export default arrayListToSentence;

--- a/src/sounds/__tests__/sounds.test.js
+++ b/src/sounds/__tests__/sounds.test.js
@@ -106,6 +106,7 @@ describe("Sounds", () => {
       {
         action: "allin",
         method: "betting",
+        bet_amount: 1000, //eslint-disable-line @typescript-eslint/camelcase
         playerid: 0
       },
       0

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -402,17 +402,17 @@ export const setUserSeat = (player: string, dispatch: Function): void => {
 };
 
 export const setWinner = (
-  player: number,
+  winnerArray: number[],
   winAmount: number,
   state: IState,
   dispatch: Function
 ): void => {
-  const winner = playerIdToString(player);
+  const winners: string[] = winnerArray.map(player => playerIdToString(player));
   nextTurn(4, state, dispatch);
   setTimeout(() => {
     dispatch({
       type: "setWinner",
-      payload: { winner, winAmount }
+      payload: { winners, winAmount }
     });
   }, 1000);
 };

--- a/src/store/initialState.ts
+++ b/src/store/initialState.ts
@@ -120,7 +120,7 @@ const initialState: IState = {
   // Where does the user sit
   userSeat: null,
   // Array of players that won
-  winners: null
+  winners: [undefined]
 };
 
 export interface IPlayer {

--- a/src/store/initialState.ts
+++ b/src/store/initialState.ts
@@ -119,7 +119,7 @@ const initialState: IState = {
   toCall: 2,
   // Where does the user sit
   userSeat: null,
-  // The player that won the game
+  // Array of players that won
   winners: null
 };
 

--- a/src/store/initialState.ts
+++ b/src/store/initialState.ts
@@ -120,7 +120,7 @@ const initialState: IState = {
   // Where does the user sit
   userSeat: null,
   // The player that won the game
-  winner: null
+  winners: null
 };
 
 export interface IPlayer {
@@ -194,7 +194,7 @@ export interface IState {
   totalPot: number;
   toCall: number;
   userSeat: string;
-  winner: string | null;
+  winners: string[] | null;
 }
 
 export default initialState;

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -276,18 +276,23 @@ const reducer: Function = (state: IState, action: IAction): object => {
       };
     }
     case "setWinner": {
+      const playersToUpdate = {};
+
+      // Update each players chips with the win amount
+      action.payload.winners.forEach((player: string) => {
+        playersToUpdate[player] = {
+          ...state.players[player],
+          chips: state.players[player].chips + action.payload.winAmount
+        };
+      });
+
       return {
         ...state,
         players: {
           ...state.players,
-          [action.payload.winner]: {
-            ...state.players[action.payload.winner],
-            chips:
-              state.players[action.payload.winner].chips +
-              action.payload.winAmount
-          }
+          ...playersToUpdate
         },
-        winner: action.payload.winner
+        winners: action.payload.winners
       };
     }
     case "doShowDown": {

--- a/src/store/testState.ts
+++ b/src/store/testState.ts
@@ -135,7 +135,7 @@ const initialState: IState = {
   // Where does the user sit
   userSeat: "player1",
   // The player that won the game
-  winner: null
+  winners: [undefined]
 };
 
 export default initialState;


### PR DESCRIPTION
This PR updates the logic so that we can handle split pots - i.e. the scenario more than one player wins. It addresses the first sub-task of #79.