### PR TITLE
Tighten dispatch type to object => void

### DIFF
--- a/src/components/Controls/Controls.tsx
+++ b/src/components/Controls/Controls.tsx
@@ -21,7 +21,7 @@ import { Possibilities, PlayerActions } from "../../lib/constants";
 // when the player is active
 
 const Controls: React.FunctionComponent = () => {
-  const dispatch: Function = useContext(DispatchContext);
+  const dispatch: (arg: object) => void = useContext(DispatchContext);
   const state: IState = useContext(StateContext);
   const {
     controls,

--- a/src/components/DeveloperMode/DeveloperMode.tsx
+++ b/src/components/DeveloperMode/DeveloperMode.tsx
@@ -14,7 +14,7 @@ import { DispatchContext, StateContext } from "../../store/context";
 import { IState } from "../../store/initialState";
 
 const DeveloperMode: React.FunctionComponent = () => {
-  const dispatch: Function = useContext(DispatchContext);
+  const dispatch: (arg: object) => void = useContext(DispatchContext);
   const state: IState = useContext(StateContext);
   const { activePlayer, userSeat } = state;
 
@@ -52,7 +52,10 @@ const DeveloperMode: React.FunctionComponent = () => {
             {
               method: "finalInfo",
               showInfo: {
-                allHoleCardsInfo: [["5D", "3H"], ["2C", "7D"]],
+                allHoleCardsInfo: [
+                  ["5D", "3H"],
+                  ["2C", "7D"]
+                ],
                 boardCardInfo: ["9S", "4D", "KD", "5H", "AC"]
               },
               win_amount: 4000000,

--- a/src/components/Game/Game.tsx
+++ b/src/components/Game/Game.tsx
@@ -12,7 +12,7 @@ import { IState } from "../../store/initialState";
 const SOCKET_URL_ECHO = "wss://echo.websocket.org";
 
 const Game: React.FunctionComponent = () => {
-  const dispatch: Function = useContext(DispatchContext);
+  const dispatch: (arg: object) => void = useContext(DispatchContext);
   const state: IState = useContext(StateContext);
   const {
     gameStarted,

--- a/src/components/Game/WebSocket.ts
+++ b/src/components/Game/WebSocket.ts
@@ -18,7 +18,7 @@ interface IProps {
 }
 
 const WebSocket = React.memo(({ message, nodeName, server }: IProps) => {
-  const dispatch: Function = useContext(DispatchContext);
+  const dispatch: (arg: object) => void = useContext(DispatchContext);
   const state: IState = useContext(StateContext);
   const [currentSocketUrl, setCurrentSocketUrl] = useState(server);
   const [sendMessage, lastMessage, readyState] = useWebSocket(

--- a/src/components/Game/onMessage.ts
+++ b/src/components/Game/onMessage.ts
@@ -77,7 +77,7 @@ const { preFlop, flop, turn, showDown } = GameTurns;
 export const onMessage = (
   messageString: string,
   state: IState,
-  dispatch: Function
+  dispatch: (arg: object) => void
 ): void => {
   const message: IMessage = JSON.parse(messageString);
 
@@ -137,7 +137,7 @@ export const onMessage = (
 export const onMessage_bvv = (
   messageString: string,
   state: IState,
-  dispatch: Function
+  dispatch: (arg: object) => void
 ): void => {
   const message: IMessage = JSON.parse(messageString);
 
@@ -164,7 +164,7 @@ export const onMessage_player = (
   messageString: string,
   player: string,
   state: IState,
-  dispatch: Function
+  dispatch: (arg: object) => void
 ): void => {
   const playerId: number = playerStringToId(player);
 

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -42,7 +42,7 @@ const Player: React.FunctionComponent<IProps> = ({
   showCards,
   winner
 }) => {
-  const dispatch: Function = useContext(DispatchContext);
+  const dispatch: (arg: object) => void = useContext(DispatchContext);
   const state: IState = useContext(StateContext);
 
   const {

--- a/src/components/StartupModal/CustomIP.tsx
+++ b/src/components/StartupModal/CustomIP.tsx
@@ -87,7 +87,7 @@ const Label = styled.div`
 `;
 
 const CustomIP: React.FunctionComponent = () => {
-  const dispatch: Function = useContext(DispatchContext);
+  const dispatch: (arg: object) => void = useContext(DispatchContext);
   const state: IState = useContext(StateContext);
 
   const [nodes, setNodes] = useState({

--- a/src/components/StartupModal/StartupModal.tsx
+++ b/src/components/StartupModal/StartupModal.tsx
@@ -9,7 +9,7 @@ import { IState } from "../../store/initialState";
 // This is the modal that appears at the startup and let's the user to join a table
 
 interface IProps {
-  dispatch: Function;
+  dispatch: (arg: object) => void;
   state: IState;
 }
 

--- a/src/components/StartupModal/TableSelect.tsx
+++ b/src/components/StartupModal/TableSelect.tsx
@@ -13,7 +13,7 @@ import {
 import { IState } from "../../store/initialState";
 
 interface IProps {
-  dispatch: Function;
+  dispatch: (arg: object) => void;
   state: IState;
 }
 

--- a/src/components/Table/TotalPot.tsx
+++ b/src/components/Table/TotalPot.tsx
@@ -9,7 +9,7 @@ import { IState } from "../../store/initialState";
 
 interface IProps {
   state: IState;
-  dispatch: Function;
+  dispatch: (arg: object) => void;
 }
 
 const TotalPot: React.FunctionComponent<IProps> = ({ state, dispatch }) => {

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -12,7 +12,7 @@ const { preFlop, flop, turn } = GameTurns;
 // Add logs to the hand history to display them in the LogBox
 export const addToHandHistory = (
   lastAction: string,
-  dispatch: Function
+  dispatch: (arg: object) => void
 ): void => {
   dispatch({
     type: "addToHandHistory",
@@ -25,7 +25,7 @@ export const bet = (
   player: string | number,
   betAmount: number,
   state: IState,
-  dispatch: Function
+  dispatch: (arg: object) => void
 ): void => {
   // Convert the player parameter to a string if needed
   if (typeof player === "number") {
@@ -69,7 +69,10 @@ export const log = (text: string, color: string, message?: IMessage): void => {
 };
 
 // Collect the chips from the player before a new turn
-export const collectChips = (state: IState, dispatch: Function): void => {
+export const collectChips = (
+  state: IState,
+  dispatch: (arg: object) => void
+): void => {
   dispatch({
     type: "collectChips"
   });
@@ -84,7 +87,10 @@ export const collectChips = (state: IState, dispatch: Function): void => {
   }
 };
 
-export const connectPlayer = (player: string, dispatch: Function): void => {
+export const connectPlayer = (
+  player: string,
+  dispatch: (arg: object) => void
+): void => {
   dispatch({
     type: "connectPlayer",
     payload: player
@@ -92,7 +98,7 @@ export const connectPlayer = (player: string, dispatch: Function): void => {
 };
 
 // Closes the Startup Modal
-export const closeStartupModal = (dispatch: Function) => {
+export const closeStartupModal = (dispatch: (arg: object) => void) => {
   dispatch({
     type: "closeStartupModal"
   });
@@ -102,7 +108,7 @@ export const closeStartupModal = (dispatch: Function) => {
 export const deal = (
   message: IMessage,
   state: IState,
-  dispatch: Function
+  dispatch: (arg: object) => void
 ): void => {
   const { holecards, board } = message.deal;
   const { gameTurn } = state;
@@ -150,21 +156,24 @@ export const deal = (
 };
 
 // Trigger the card deal animation
-export const dealCards = (dispatch: Function): void => {
+export const dealCards = (dispatch: (arg: object) => void): void => {
   dispatch({
     type: "dealCards"
   });
 };
 
 // Set up the state for Developer Mode
-export const devStart = (dispatch: Function): void => {
+export const devStart = (dispatch: (arg: object) => void): void => {
   dispatch({
     type: "devStart"
   });
 };
 
 // Triggers the showDown
-export const doShowDown = (allHoleCardsInfo: string[], dispatch: Function) => {
+export const doShowDown = (
+  allHoleCardsInfo: string[],
+  dispatch: (arg: object) => void
+) => {
   dispatch({
     type: "doShowDown",
     payload: allHoleCardsInfo
@@ -172,7 +181,7 @@ export const doShowDown = (allHoleCardsInfo: string[], dispatch: Function) => {
 };
 
 // Fold player action
-export const fold = (player: string, dispatch: Function): void => {
+export const fold = (player: string, dispatch: (arg: object) => void): void => {
   dispatch({
     type: "fold",
     payload: player
@@ -183,7 +192,7 @@ export const fold = (player: string, dispatch: Function): void => {
 export const game = (
   gameObject: { gametype: string; pot: number[] },
   state: IState,
-  dispatch: Function
+  dispatch: (arg: object) => void
 ): void => {
   if (state.gameStarted === false) {
     dispatch({
@@ -200,7 +209,7 @@ export const game = (
 export const nextTurn = (
   turn: number,
   state: IState,
-  dispatch: Function
+  dispatch: (arg: object) => void
 ): void => {
   collectChips(state, dispatch);
   setActivePlayer(null, dispatch);
@@ -213,7 +222,10 @@ export const nextTurn = (
   setLastAction(1, null, dispatch);
 };
 
-export const nextHand = (state: IState, dispatch: Function): void => {
+export const nextHand = (
+  state: IState,
+  dispatch: (arg: object) => void
+): void => {
   setActivePlayer(null, dispatch);
   updateGameTurn(0, dispatch);
   resetTurn(state.blinds[1], dispatch);
@@ -225,7 +237,7 @@ export const nextHand = (state: IState, dispatch: Function): void => {
 export const playerJoin = (
   player: string,
   state: IState,
-  dispatch: Function
+  dispatch: (arg: object) => void
 ): void => {
   const id = Number(player.slice(-1)) - 1;
   sendMessage(
@@ -239,7 +251,7 @@ export const playerJoin = (
 // Defines which buttons to show in Controls by processsing the possibilities array
 export const processControls = (
   receivedPossibilities: number[],
-  dispatch: Function
+  dispatch: (arg: object) => void
 ): void => {
   const canCheck = receivedPossibilities.some(
     poss => poss === Possibilities.check
@@ -257,7 +269,10 @@ export const processControls = (
   });
 };
 
-export const resetMessage = (node: string, dispatch: Function): void => {
+export const resetMessage = (
+  node: string,
+  dispatch: (arg: object) => void
+): void => {
   dispatch({
     type: "setMessage",
     payload: {
@@ -267,7 +282,10 @@ export const resetMessage = (node: string, dispatch: Function): void => {
   });
 };
 
-export const resetTurn = (bigBlind: number, dispatch: Function): void => {
+export const resetTurn = (
+  bigBlind: number,
+  dispatch: (arg: object) => void
+): void => {
   dispatch({
     type: "resetTurn",
     payload: bigBlind
@@ -276,7 +294,7 @@ export const resetTurn = (bigBlind: number, dispatch: Function): void => {
 
 export const seats = (
   seatsArray: [{ name: string; playing: number; seat: number }],
-  dispatch: Function
+  dispatch: (arg: object) => void
 ): void => {
   seatsArray.map(seat => {
     dispatch({
@@ -294,7 +312,7 @@ export const sendMessage = (
   message: IMessage,
   node: string,
   state: IState,
-  dispatch: Function
+  dispatch: (arg: object) => void
 ): void => {
   if (state.connection[node] === "Connected") {
     dispatch({
@@ -307,7 +325,10 @@ export const sendMessage = (
   } else !state.isDeveloperMode && alert(`Error: ${node} is not connected.`);
 };
 
-export const setActivePlayer = (player: string, dispatch: Function): void => {
+export const setActivePlayer = (
+  player: string,
+  dispatch: (arg: object) => void
+): void => {
   dispatch({
     type: "setActivePlayer",
     payload: player
@@ -317,7 +338,7 @@ export const setActivePlayer = (player: string, dispatch: Function): void => {
 export const setBalance = (
   player: string,
   balance: number,
-  dispatch: Function
+  dispatch: (arg: object) => void
 ): void => {
   dispatch({
     type: "setBalance",
@@ -327,7 +348,7 @@ export const setBalance = (
 
 export const setBlinds = (
   blinds: [number, number],
-  dispatch: Function
+  dispatch: (arg: object) => void
 ): void => {
   dispatch({
     type: "setBlinds",
@@ -337,7 +358,7 @@ export const setBlinds = (
 
 export const setBoardCards = (
   boardCards: string[],
-  dispatch: Function
+  dispatch: (arg: object) => void
 ): void => {
   dispatch({
     type: "setBoardCards",
@@ -345,14 +366,20 @@ export const setBoardCards = (
   });
 };
 
-export const setDealer = (player: number, dispatch: Function): void => {
+export const setDealer = (
+  player: number,
+  dispatch: (arg: object) => void
+): void => {
   dispatch({
     type: "setDealer",
     payload: player
   });
 };
 
-export const setHoleCards = (holeCards: string[], dispatch: Function): void => {
+export const setHoleCards = (
+  holeCards: string[],
+  dispatch: (arg: object) => void
+): void => {
   dispatch({
     type: "setHoleCards",
     payload: holeCards
@@ -362,7 +389,7 @@ export const setHoleCards = (holeCards: string[], dispatch: Function): void => {
 export const setLastAction = (
   player: number,
   action: string | IMessage | null,
-  dispatch: Function
+  dispatch: (arg: object) => void
 ): void => {
   dispatch({
     type: "setLastAction",
@@ -373,28 +400,40 @@ export const setLastAction = (
   });
 };
 
-export const setLastMessage = (message: IMessage, dispatch: Function): void => {
+export const setLastMessage = (
+  message: IMessage,
+  dispatch: (arg: object) => void
+): void => {
   dispatch({
     type: "setLastMessage",
     payload: message
   });
 };
 
-export const setMinRaiseTo = (amount: number, dispatch: Function): void => {
+export const setMinRaiseTo = (
+  amount: number,
+  dispatch: (arg: object) => void
+): void => {
   dispatch({
     type: "setMinRaiseTo",
     payload: amount
   });
 };
 
-export const setToCall = (amount: number, dispatch: Function): void => {
+export const setToCall = (
+  amount: number,
+  dispatch: (arg: object) => void
+): void => {
   dispatch({
     type: "setToCall",
     payload: amount
   });
 };
 
-export const setUserSeat = (player: string, dispatch: Function): void => {
+export const setUserSeat = (
+  player: string,
+  dispatch: (arg: object) => void
+): void => {
   dispatch({
     type: "setUserSeat",
     payload: player
@@ -405,7 +444,7 @@ export const setWinner = (
   winnerArray: number[],
   winAmount: number,
   state: IState,
-  dispatch: Function
+  dispatch: (arg: object) => void
 ): void => {
   const winners: string[] = winnerArray.map(playerIdToString);
   nextTurn(4, state, dispatch);
@@ -417,34 +456,46 @@ export const setWinner = (
   }, 1000);
 };
 
-export const showControls = (show: boolean, dispatch: Function): void => {
+export const showControls = (
+  show: boolean,
+  dispatch: (arg: object) => void
+): void => {
   dispatch({
     type: "showControls",
     payload: show
   });
 };
 
-export const toggleMainPot = (dispatch: Function): void => {
+export const toggleMainPot = (dispatch: (arg: object) => void): void => {
   dispatch({
     type: "toggleMainPot"
   });
 };
 
-export const updateGameTurn = (turn: number, dispatch: Function): void => {
+export const updateGameTurn = (
+  turn: number,
+  dispatch: (arg: object) => void
+): void => {
   dispatch({
     type: "updateGameTurn",
     payload: turn
   });
 };
 
-export const updateMainPot = (amount: number, dispatch: Function): void => {
+export const updateMainPot = (
+  amount: number,
+  dispatch: (arg: object) => void
+): void => {
   dispatch({
     type: "updateMainPot",
     payload: amount
   });
 };
 
-export const updateTotalPot = (amount: number, dispatch: Function): void => {
+export const updateTotalPot = (
+  amount: number,
+  dispatch: (arg: object) => void
+): void => {
   dispatch({
     type: "updateTotalPot",
     payload: amount
@@ -454,7 +505,7 @@ export const updateTotalPot = (amount: number, dispatch: Function): void => {
 export const updateStateValue = (
   key: string,
   value: any,
-  dispatch: Function
+  dispatch: (arg: object) => void
 ): void => {
   dispatch({
     type: "updateStateValue",


### PR DESCRIPTION
As pointed out in [this comment](https://github.com/chips-blockchain/pangea-poker/pull/84#discussion_r373739109), using `object => void` type definition for `dispatch` is better than using the more generic `Function`. 

Therefore, this PR simply replaces all the `dispatch` types throughout the application.