### PR TITLE
Add address validation and unit tests to Deposit and Cashier

### DIFF
--- a/src/components/Cashier/Cashier.tsx
+++ b/src/components/Cashier/Cashier.tsx
@@ -35,7 +35,12 @@ const Cashier: React.FunctionComponent<IProps> = ({ dispatch, state }) => {
     <React.Fragment>
       {!state.isStartupModal && state.nodeType !== "dealer" && (
         <CashierButton>
-          <Button label="Cashier" onClick={openCashierModal()} small></Button>
+          <Button
+            label="Cashier"
+            onClick={openCashierModal()}
+            small
+            testId="cashier-button"
+          />
         </CashierButton>
       )}
       <Modal

--- a/src/components/Cashier/Cashier.tsx
+++ b/src/components/Cashier/Cashier.tsx
@@ -22,22 +22,36 @@ const CashierButton = styled.div`
 `;
 
 const Cashier: React.FunctionComponent<IProps> = ({ dispatch, state }) => {
-  const openCashier = () => (): void => {
+  const openCashierModal = () => (): void => {
     updateStateValue("isCashierOpen", true, dispatch);
+  };
+
+  // Close the Cashier modal
+  const closeCashierModal = () => (): void => {
+    updateStateValue("isCashierOpen", false, dispatch);
   };
 
   return (
     <React.Fragment>
       {!state.isStartupModal && state.nodeType !== "dealer" && (
         <CashierButton>
-          <Button label="Cashier" onClick={openCashier()} small></Button>
+          <Button label="Cashier" onClick={openCashierModal()} small></Button>
         </CashierButton>
       )}
       <Modal
         isOpen={state.isCashierOpen}
+        // Pass in onRequestClose to allow closing the modal with "ESC" keypress
+        // or by clicking on the overlay
+        onRequestClose={closeCashierModal()}
         tabs={[
           {
-            content: <Deposit dispatch={dispatch} state={state} />,
+            content: (
+              <Deposit
+                dispatch={dispatch}
+                state={state}
+                closeCashierModal={closeCashierModal}
+              />
+            ),
             name: "Deposit",
             title: "Deposit CHIPS"
           }

--- a/src/components/Cashier/Cashier.tsx
+++ b/src/components/Cashier/Cashier.tsx
@@ -42,6 +42,8 @@ const Cashier: React.FunctionComponent<IProps> = ({ dispatch, state }) => {
         isOpen={state.isCashierOpen}
         // Pass in onRequestClose to allow closing the modal with "ESC" keypress
         // or by clicking on the overlay
+        id="cashier-modal"
+        contentLabel="Cashier Modal"
         onRequestClose={closeCashierModal()}
         tabs={[
           {

--- a/src/components/Cashier/Deposit.tsx
+++ b/src/components/Cashier/Deposit.tsx
@@ -7,12 +7,12 @@ import balanceWithDecimals from "../../lib/balanceWithDecimals";
 import isValidAddress from "../../lib/isValidAddress";
 import ModalButtonsWrapper from "../Modal/ModalButtonsWrapper";
 import { Button } from "../Controls";
-import { updateStateValue } from "../../store/actions";
 import "../../styles/tooltip.css";
 
 interface IProps {
   dispatch: (arg: object) => void;
   state: IState;
+  closeCashierModal: Function;
 }
 
 const AdditionalInfo = styled.p`
@@ -45,7 +45,10 @@ const DepositAddressContainer = styled.div`
   padding: 0.5rem;
 `;
 
-const Deposit: React.FunctionComponent<IProps> = ({ state, dispatch }) => {
+const Deposit: React.FunctionComponent<IProps> = ({
+  state,
+  closeCashierModal
+}) => {
   const { balance, depositAddress } = state;
 
   const [isAddressCopied, setIsAddressCopied] = useState(false);
@@ -55,11 +58,6 @@ const Deposit: React.FunctionComponent<IProps> = ({ state, dispatch }) => {
   useEffect(() => {
     setIsDepositAddressValid(isValidAddress(depositAddress));
   }, [balance]);
-
-  // Close the Cashier modal
-  const closeCashierModal = () => (): void => {
-    updateStateValue("isCashierOpen", false, dispatch);
-  };
 
   // Copy the address to the clipboard and hide the tooltip when clicked
   const copyToClipBoard = () => (): void => {
@@ -81,7 +79,8 @@ const Deposit: React.FunctionComponent<IProps> = ({ state, dispatch }) => {
       <AddressLabel>Your CHIPS deposit address:</AddressLabel>
       <DepositAddressContainer
         data-tip={isAddressCopied ? "Copied!" : "Copy to Clipboard"}
-        onClick={isDepositAddressValid && copyToClipBoard()}
+        onClick={isDepositAddressValid ? copyToClipBoard() : undefined}
+        data-test="address-container-cashier-deposit"
       >
         <DepositAddress css={cursorStyle} data-test="address-cashier-deposit">
           {isDepositAddressValid ? depositAddress : "Invalid address"}

--- a/src/components/Cashier/Deposit.tsx
+++ b/src/components/Cashier/Deposit.tsx
@@ -56,10 +56,12 @@ const Deposit: React.FunctionComponent<IProps> = ({ state, dispatch }) => {
     setIsDepositAddressValid(isValidAddress(depositAddress));
   }, [balance]);
 
+  // Close the Cashier modal
   const handleSubmit = () => (): void => {
     updateStateValue("isCashierOpen", false, dispatch);
   };
 
+  // Copy the address to the clipboard and hide the tooltip when clicked
   const copyToClipBoard = () => (): void => {
     navigator.clipboard.writeText(depositAddress);
     setIsAddressCopied(true);

--- a/src/components/Cashier/Deposit.tsx
+++ b/src/components/Cashier/Deposit.tsx
@@ -57,7 +57,7 @@ const Deposit: React.FunctionComponent<IProps> = ({ state, dispatch }) => {
   }, [balance]);
 
   // Close the Cashier modal
-  const handleSubmit = () => (): void => {
+  const closeCashierModal = () => (): void => {
     updateStateValue("isCashierOpen", false, dispatch);
   };
 
@@ -94,7 +94,7 @@ const Deposit: React.FunctionComponent<IProps> = ({ state, dispatch }) => {
       <ModalButtonsWrapper>
         <Button
           label="Close"
-          onClick={handleSubmit()}
+          onClick={closeCashierModal()}
           data-test="close-cashier-deposit"
         />
       </ModalButtonsWrapper>

--- a/src/components/Cashier/Deposit.tsx
+++ b/src/components/Cashier/Deposit.tsx
@@ -3,6 +3,7 @@ import styled from "@emotion/styled";
 import ReactTooltip from "react-tooltip";
 import { IState } from "../../store/initialState";
 import balanceWithDecimals from "../../lib/balanceWithDecimals";
+import isValidAddress from "../../lib/isValidAddress";
 import ModalButtonsWrapper from "../Modal/ModalButtonsWrapper";
 import { Button } from "../Controls";
 import { updateStateValue } from "../../store/actions";
@@ -67,7 +68,9 @@ const Deposit: React.FunctionComponent<IProps> = ({ state, dispatch }) => {
         data-tip={isAddressCopied ? "Copied!" : "Copy to Clipboard"}
         onClick={copyToClipBoard()}
       >
-        <DepositAddress>{depositAddress}</DepositAddress>
+        <DepositAddress>
+          {isValidAddress(depositAddress) ? depositAddress : "Invalid address"}
+        </DepositAddress>
       </DepositAddressContainer>
       <AdditionalInfo>
         Please only deposit CHIPS to this address. Transactions might take up to

--- a/src/components/Cashier/Deposit.tsx
+++ b/src/components/Cashier/Deposit.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { css } from "@emotion/core";
 import styled from "@emotion/styled";
 import ReactTooltip from "react-tooltip";
 import { IState } from "../../store/initialState";
@@ -35,7 +36,6 @@ const Balance = styled.div`
 const DepositAddress = styled.span`
   color: var(--primaryLight);
   font-size: 0.875rem;
-  cursor: pointer;
 `;
 
 const DepositAddressContainer = styled.div`
@@ -66,6 +66,11 @@ const Deposit: React.FunctionComponent<IProps> = ({ state, dispatch }) => {
     ReactTooltip.hide();
   };
 
+  // Set the cursor style based on whether the deposit address is valid
+  const cursorStyle = css`
+    cursor: ${isDepositAddressValid ? "pointer" : "not-allowed"};
+  `;
+
   return (
     <section>
       <Balance data-test="balance-cashier-deposit">
@@ -76,7 +81,7 @@ const Deposit: React.FunctionComponent<IProps> = ({ state, dispatch }) => {
         data-tip={isAddressCopied ? "Copied!" : "Copy to Clipboard"}
         onClick={isDepositAddressValid && copyToClipBoard()}
       >
-        <DepositAddress data-test="address-cashier-deposit">
+        <DepositAddress css={cursorStyle} data-test="address-cashier-deposit">
           {isDepositAddressValid ? depositAddress : "Invalid address"}
         </DepositAddress>
       </DepositAddressContainer>

--- a/src/components/Cashier/Deposit.tsx
+++ b/src/components/Cashier/Deposit.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styled from "@emotion/styled";
 import ReactTooltip from "react-tooltip";
 import { IState } from "../../store/initialState";
@@ -49,6 +49,12 @@ const Deposit: React.FunctionComponent<IProps> = ({ state, dispatch }) => {
   const { balance, depositAddress } = state;
 
   const [isAddressCopied, setIsAddressCopied] = useState(false);
+  const [isDepositAddressValid, setIsDepositAddressValid] = useState(false);
+
+  // Validate if the deposit address is correct
+  useEffect(() => {
+    setIsDepositAddressValid(isValidAddress(depositAddress));
+  }, [balance]);
 
   const handleSubmit = () => (): void => {
     updateStateValue("isCashierOpen", false, dispatch);
@@ -62,14 +68,16 @@ const Deposit: React.FunctionComponent<IProps> = ({ state, dispatch }) => {
 
   return (
     <section>
-      <Balance>Available CHIPS: {balanceWithDecimals(balance)}</Balance>
+      <Balance data-test="balance-cashier-deposit">
+        Available CHIPS: {balanceWithDecimals(balance)}
+      </Balance>
       <AddressLabel>Your CHIPS deposit address:</AddressLabel>
       <DepositAddressContainer
         data-tip={isAddressCopied ? "Copied!" : "Copy to Clipboard"}
-        onClick={copyToClipBoard()}
+        onClick={isDepositAddressValid && copyToClipBoard()}
       >
-        <DepositAddress>
-          {isValidAddress(depositAddress) ? depositAddress : "Invalid address"}
+        <DepositAddress data-test="address-cashier-deposit">
+          {isDepositAddressValid ? depositAddress : "Invalid address"}
         </DepositAddress>
       </DepositAddressContainer>
       <AdditionalInfo>
@@ -83,7 +91,7 @@ const Deposit: React.FunctionComponent<IProps> = ({ state, dispatch }) => {
           data-test="close-cashier-deposit"
         />
       </ModalButtonsWrapper>
-      <ReactTooltip className="react-tooltip" />
+      {isDepositAddressValid && <ReactTooltip className="react-tooltip" />}
     </section>
   );
 };

--- a/src/components/Cashier/__tests__/Cashier.test.js
+++ b/src/components/Cashier/__tests__/Cashier.test.js
@@ -7,6 +7,9 @@ import * as actions from "../../../store/actions";
 
 const dispatch = jest.fn();
 
+jest.spyOn(actions, "updateStateValue");
+const { updateStateValue } = actions;
+
 const buildWrapper = (dispatch, state) => {
   return mount(
     <DispatchContext.Provider value={dispatch}>
@@ -47,8 +50,6 @@ describe("Cashier", () => {
   test("is closed when close button is clicked on Deposit tab", () => {
     const state = { ...initialState, isCashierOpen: true };
     const wrapper = buildWrapper(dispatch, state);
-    jest.spyOn(actions, "updateStateValue");
-    const { updateStateValue } = actions;
 
     expect(
       wrapper
@@ -62,6 +63,38 @@ describe("Cashier", () => {
     expect(updateStateValue).toHaveBeenCalledWith(
       "isCashierOpen",
       false,
+      dispatch
+    );
+  });
+
+  test("shows the cashier button for player nodes", () => {
+    const state = {
+      ...initialState,
+      isCashierOpen: false,
+      nodeType: "player",
+      isStartupModal: false
+    };
+    const wrapper = buildWrapper(dispatch, state);
+
+    expect(wrapper.find(`button[data-testid="cashier-button"]`)).toHaveLength(
+      1
+    );
+  });
+
+  test("opens when the Cashier button is clicked", () => {
+    const state = {
+      ...initialState,
+      isCashierOpen: false,
+      nodeType: "player",
+      isStartupModal: false
+    };
+    const wrapper = buildWrapper(dispatch, state);
+
+    wrapper.find(`button[data-testid="cashier-button"]`).simulate("click");
+    expect(updateStateValue).toHaveBeenCalled();
+    expect(updateStateValue).toHaveBeenCalledWith(
+      "isCashierOpen",
+      true,
       dispatch
     );
   });

--- a/src/components/Cashier/__tests__/Cashier.test.js
+++ b/src/components/Cashier/__tests__/Cashier.test.js
@@ -1,0 +1,68 @@
+import React from "react";
+import { mount } from "enzyme";
+import Cashier from "../Cashier";
+import { StateContext, DispatchContext } from "../../../store/context";
+import initialState from "../../../store/initialState";
+import * as actions from "../../../store/actions";
+
+const dispatch = jest.fn();
+
+const buildWrapper = (dispatch, state) => {
+  return mount(
+    <DispatchContext.Provider value={dispatch}>
+      <StateContext.Provider value={state}>
+        <div id="root">
+          <Cashier state={state} dispatch={dispatch} />
+        </div>
+      </StateContext.Provider>
+    </DispatchContext.Provider>
+  );
+};
+
+describe("Cashier", () => {
+  test("is shown", () => {
+    const state = { ...initialState, isCashierOpen: true };
+    const wrapper = buildWrapper(dispatch, state);
+
+    expect(
+      wrapper
+        .find(`#cashier-modal`)
+        .first()
+        .prop("isOpen")
+    ).toBe(true);
+  });
+
+  test("is hidden", () => {
+    const state = { ...initialState, isCashierOpen: false };
+    const wrapper = buildWrapper(dispatch, state);
+
+    expect(
+      wrapper
+        .find(`#cashier-modal`)
+        .first()
+        .prop("isOpen")
+    ).toBe(false);
+  });
+
+  test("is closed when close button is clicked on Deposit tab", () => {
+    const state = { ...initialState, isCashierOpen: true };
+    const wrapper = buildWrapper(dispatch, state);
+    jest.spyOn(actions, "updateStateValue");
+    const { updateStateValue } = actions;
+
+    expect(
+      wrapper
+        .find(`#cashier-modal`)
+        .first()
+        .prop("isOpen")
+    ).toBe(true);
+
+    wrapper.find(`[data-test="close-cashier-deposit"]`).simulate("click");
+    expect(updateStateValue).toHaveBeenCalled();
+    expect(updateStateValue).toHaveBeenCalledWith(
+      "isCashierOpen",
+      false,
+      dispatch
+    );
+  });
+});

--- a/src/components/Cashier/__tests__/Deposit.test.js
+++ b/src/components/Cashier/__tests__/Deposit.test.js
@@ -1,0 +1,100 @@
+import React from "react";
+import { mount } from "enzyme";
+import Deposit from "../Deposit";
+import { StateContext, DispatchContext } from "../../../store/context";
+import initialState from "../../../store/initialState";
+
+const dispatch = jest.fn();
+const closeCashierModal = jest.fn();
+
+const buildWrapper = (dispatch, state) => {
+  return mount(
+    <DispatchContext.Provider value={dispatch}>
+      <StateContext.Provider value={state}>
+        <Deposit
+          state={state}
+          dispatch={dispatch}
+          closeCashierModal={closeCashierModal}
+        />
+      </StateContext.Provider>
+    </DispatchContext.Provider>
+  );
+};
+
+describe("Deposit", () => {
+  test("displays correct CHIPS balance", () => {
+    const state = { ...initialState, isCashierOpen: true, balance: 8 };
+    const wrapper = buildWrapper(dispatch, state);
+
+    expect(
+      wrapper.find(`div[data-test="balance-cashier-deposit"]`).text()
+    ).toBe("Available CHIPS: 8.00000000");
+  });
+
+  test("displays correct deposit address", () => {
+    const state = {
+      ...initialState,
+      depositAddress: "123456789a123456789a123456789a1234"
+    };
+    const wrapper = buildWrapper(dispatch, state);
+
+    expect(
+      wrapper.find(`span[data-test="address-cashier-deposit"]`).text()
+    ).toBe("123456789a123456789a123456789a1234");
+  });
+
+  test("displays the error message for invalid addresses", () => {
+    const state = {
+      ...initialState,
+      depositAddress: "123456789a123456789a123456789a1234*"
+    };
+    const wrapper = buildWrapper(dispatch, state);
+
+    expect(
+      wrapper.find(`span[data-test="address-cashier-deposit"]`).text()
+    ).toBe("Invalid address");
+  });
+
+  test("Copies the deposit address to the clipboard after clicking on the address bar", () => {
+    const depositAddress = "123456789a123456789a123456789a1234";
+    const state = {
+      ...initialState,
+      depositAddress
+    };
+    const wrapper = buildWrapper(dispatch, state);
+
+    navigator.clipboard = { writeText: jest.fn() };
+
+    wrapper
+      .find(`div[data-test="address-container-cashier-deposit"]`)
+      .simulate("click");
+    expect(navigator.clipboard.writeText).toHaveBeenCalled();
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(depositAddress);
+  });
+
+  test("Does not copy the deposit address to the clipboard when the address is invalid", () => {
+    const depositAddress = "123456789a123456789a123456789a1234*";
+    const state = {
+      ...initialState,
+      depositAddress
+    };
+    const wrapper = buildWrapper(dispatch, state);
+
+    navigator.clipboard = { writeText: jest.fn() };
+
+    wrapper
+      .find(`div[data-test="address-container-cashier-deposit"]`)
+      .simulate("click");
+    expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(0);
+  });
+
+  test("Closes the cashier modal when clicking close button", () => {
+    const state = {
+      ...initialState
+    };
+    const wrapper = buildWrapper(dispatch, state);
+
+    wrapper.find(`[data-test="close-cashier-deposit"]`).simulate("click");
+    expect(closeCashierModal).toHaveBeenCalled();
+  });
+});

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -5,12 +5,14 @@ import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 
 interface IProps {
   children?: React.ReactNode;
+  contentLabel: string;
+  id: string;
   isOpen: boolean;
   tabs?: { content: React.ReactNode; title: string; name: string }[];
   onRequestClose: Function;
 }
-
-ReactModal.setAppElement("#root");
+const isTest = process.env.NODE_ENV === "test";
+!isTest && ReactModal.setAppElement("#root");
 
 const modalStyle = {
   content: {
@@ -47,6 +49,8 @@ const tabsStyle = css`
 
 const Modal: React.FunctionComponent<IProps> = ({
   children,
+  contentLabel,
+  id,
   isOpen,
   onRequestClose,
   tabs
@@ -55,7 +59,10 @@ const Modal: React.FunctionComponent<IProps> = ({
     <ReactModal
       isOpen={isOpen}
       style={modalStyle}
+      contentLabel={contentLabel}
+      id={id}
       onRequestClose={onRequestClose}
+      ariaHideApp={isTest ? false : true}
     >
       {tabs && (
         <Tabs css={tabsStyle}>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -5,8 +5,9 @@ import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 
 interface IProps {
   children?: React.ReactNode;
-  tabs?: { content: React.ReactNode; title: string; name: string }[];
   isOpen: boolean;
+  tabs?: { content: React.ReactNode; title: string; name: string }[];
+  onRequestClose: Function;
 }
 
 ReactModal.setAppElement("#root");
@@ -44,9 +45,18 @@ const tabsStyle = css`
   }
 `;
 
-const Modal: React.FunctionComponent<IProps> = ({ children, tabs, isOpen }) => {
+const Modal: React.FunctionComponent<IProps> = ({
+  children,
+  isOpen,
+  onRequestClose,
+  tabs
+}) => {
   return (
-    <ReactModal isOpen={isOpen} style={modalStyle}>
+    <ReactModal
+      isOpen={isOpen}
+      style={modalStyle}
+      onRequestClose={onRequestClose}
+    >
       {tabs && (
         <Tabs css={tabsStyle}>
           <TabList>

--- a/src/lib/__tests__/isValidAddress.test.ts
+++ b/src/lib/__tests__/isValidAddress.test.ts
@@ -1,0 +1,22 @@
+import isValidAddress from "../isValidAddress";
+
+describe("Validates CHIPS addresses", () => {
+  test("Only 26 to 35 charachter long addresses are valid", () => {
+    expect(isValidAddress("123456789a123456789a123456")).toBe(true);
+    expect(isValidAddress("123456789a123456789a123456789")).toBe(true);
+    expect(isValidAddress("123456789a123456789a123456789a12345")).toBe(true);
+    expect(isValidAddress("123456789a123456789a123456789a123456")).toBe(false);
+    expect(isValidAddress("123456789a123456789a123456789a123456789a")).toBe(
+      false
+    );
+  });
+  test("Only alphanumberic numbers accepted, except 'I' 'l' 'O' and '0'", () => {
+    expect(isValidAddress("123456789a123456789a123456")).toBe(true);
+    expect(isValidAddress("123456789a123456789a12345O")).toBe(false);
+    expect(isValidAddress("123456789a123456789a12345I")).toBe(false);
+    expect(isValidAddress("123456789a123456789a123450")).toBe(false);
+    expect(isValidAddress("123456789a123456789a12345l")).toBe(false);
+    expect(isValidAddress("123456789a123456789a12345*")).toBe(false);
+    expect(isValidAddress("123456789a123456789a12345 ")).toBe(false);
+  });
+});

--- a/src/lib/isValidAddress.ts
+++ b/src/lib/isValidAddress.ts
@@ -1,0 +1,8 @@
+// Validates whether the deposit address is a valid CHIPS address
+
+const isValidAddress = (address: string): boolean => {
+  const reg = /^[a-km-zA-HJ-NP-Z1-9]{26,35}$/;
+  return reg.test(address);
+};
+
+export default isValidAddress;


### PR DESCRIPTION
This PR improves a few things regarding the Cashier modal and the Deposit tab:

- Adds basic CHIPS address validation
- Adds UI clues for invalid address
- Enables modal close by pressing the ESC key or clicking on the overlay area
- Adds unit tests

![cashier-deposit-2](https://user-images.githubusercontent.com/17296915/74414904-3dcaec00-4e3a-11ea-9d1f-038fed064c7c.gif)


