### PR TITLE
Add build/release automation to Electron

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+# https://github.com/marketplace/actions/electron-builder-action
+
+name: Build/release
+
+on: push
+
+jobs:
+  release:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v1
+
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10
+
+      - name: Build/release Electron app
+        uses: samuelmeuli/action-electron-builder@v1
+        with:
+          # GitHub token, automatically provided to the action
+          # (No need to define this secret in the repo settings)
+          github_token: ${{ secrets.github_token }}
+
+          # If the commit is tagged with a version (e.g. "v1.0.0"),
+          # release the app after building
+          release: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pangea-poker-gui",
   "version": "0.4.0",
-  "description": "",
+  "description": "Decentralized Poker via the CHIPS Blockchain",
   "main": "src/electron.js",
   "scripts": {
     "build": "parcel build src/index.html --out-dir build --public-url ./",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "src/electron.js",
   "scripts": {
-    "build": "parcel build src/index.html --out-dir build --public-url ./ && npm run electron-pack",
+    "build": "parcel build src/index.html --out-dir build --public-url ./",
     "dev": "parcel src/index.html",
     "electron-dev": "concurrently \"BROWSER=none npm start\" \"wait-on http://localhost:1234 && electron .\"",
     "electron-pack": "electron-builder -mwl",


### PR DESCRIPTION
This PR adds a new [action](https://github.com/marketplace/actions/electron-builder-action) that enables CI/CD for the building and releasing the app. 