### PR TITLE
fix(gui): default backend host to localhost instead of dev IP

### DIFF
--- a/src/components/Modal/CustomIP.tsx
+++ b/src/components/Modal/CustomIP.tsx
@@ -24,13 +24,13 @@ const nodesToInput: INode[] = [
     id: "dealer",
     type: "dealer",
     tableId: "",
-    devAddress: "159.69.23.31"
+    devAddress: "localhost"
   },
   {
     name: "player",
     id: "player",
     type: "player",
-    devAddress: "159.69.23.31"
+    devAddress: "localhost"
   }
 ];
 
@@ -38,8 +38,8 @@ const CustomIP: React.FunctionComponent = () => {
   const dispatch: (arg: object) => void = useContext(DispatchContext);
   const state: IState = useContext(StateContext);
   const [nodes, setNodes] = useState({
-    dcv: "159.69.23.31",
-    player: "159.69.23.31"
+    dcv: "localhost",
+    player: "localhost"
   });
   const [ports, setPorts] = useState({
     dcv: "9000",

--- a/src/config/development.json
+++ b/src/config/development.json
@@ -1,7 +1,7 @@
 {
     "ips": {
-        "dcv": "159.69.23.31",
-        "player": "159.69.23.31",
-        "player2": "159.69.23.31"
+        "dcv": "localhost",
+        "player": "localhost",
+        "player2": "localhost"
     }
 }


### PR DESCRIPTION
The CustomIP modal and development.json shipped with a hardcoded developer test IP (159.69.23.31). For community users running the stack locally this was confusing and required manual edits. Default to `localhost` so the GUI works out of the box for local setups; users on remote machines can still type the backend's IP into the field as before.